### PR TITLE
Fixes issue where panel body would always be the height of the screen

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -258,16 +258,12 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
             ? AnimatedBuilder(
                 animation: _ac,
                 builder: (context, child) {
-                  return Positioned(
+                  return Positioned.fill(
                     top: widget.parallaxEnabled ? _getParallax() : 0.0,
                     child: child ?? SizedBox(),
                   );
                 },
-                child: Container(
-                  height: MediaQuery.of(context).size.height,
-                  width: MediaQuery.of(context).size.width,
-                  child: widget.body,
-                ),
+                child: widget.body,
               )
             : Container(),
 


### PR DESCRIPTION
`MediaQuery.of(context).size.height` always returns the full screen height, rather than the height of the widgets parent.

If there is an appbar in a scaffold for example, the panel’s body height should only be as big as its parent, not the height of the screen.

By using Positioned.fill, the body will now fill the stack and be sized correctly.