### PR TITLE
SlidingUpPanel now uses the maximum size that the parent allows 

### DIFF
--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,1 +1,0 @@
-{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"path_provider","dependencies":[]},{"name":"sqflite","dependencies":[]}]}

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -22,6 +22,7 @@
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,7 +21,6 @@ void main() => runApp(SlidingUpPanelExample());
 class SlidingUpPanelExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-
     SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
       systemNavigationBarColor: Colors.grey[200],
       systemNavigationBarIconBrightness: Brightness.dark,
@@ -45,28 +44,26 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-
   final double _initFabHeight = 120.0;
   double _fabHeight;
   double _panelHeightOpen;
   double _panelHeightClosed = 95.0;
 
   @override
-  void initState(){
+  void initState() {
     super.initState();
 
     _fabHeight = _initFabHeight;
   }
 
   @override
-  Widget build(BuildContext context){
+  Widget build(BuildContext context) {
     _panelHeightOpen = MediaQuery.of(context).size.height * .80;
 
     return Material(
       child: Stack(
         alignment: Alignment.topCenter,
         children: <Widget>[
-
           SlidingUpPanel(
             maxHeight: _panelHeightOpen,
             minHeight: _panelHeightClosed,
@@ -74,10 +71,16 @@ class _HomePageState extends State<HomePage> {
             parallaxOffset: .5,
             body: _body(),
             panelBuilder: (sc) => _panel(sc),
-            borderRadius: BorderRadius.only(topLeft: Radius.circular(18.0), topRight: Radius.circular(18.0)),
-            onPanelSlide: (double pos) => setState((){
-              _fabHeight = pos * (_panelHeightOpen - _panelHeightClosed) + _initFabHeight;
-            }),
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(18.0),
+              topRight: Radius.circular(18.0),
+            ),
+            onPanelSlide: (double pos) => setState(
+              () {
+                _fabHeight = pos * (_panelHeightOpen - _panelHeightClosed) +
+                    _initFabHeight;
+              },
+            ),
           ),
 
           // the fab
@@ -89,7 +92,7 @@ class _HomePageState extends State<HomePage> {
                 Icons.gps_fixed,
                 color: Theme.of(context).primaryColor,
               ),
-              onPressed: (){},
+              onPressed: () {},
               backgroundColor: Colors.white,
             ),
           ),
@@ -103,9 +106,9 @@ class _HomePageState extends State<HomePage> {
                   width: MediaQuery.of(context).size.width,
                   height: MediaQuery.of(context).padding.top,
                   color: Colors.transparent,
-                )
-              )
-            )
+                ),
+              ),
+            ),
           ),
 
           //the SlidingUpPanel Title
@@ -115,36 +118,35 @@ class _HomePageState extends State<HomePage> {
               padding: const EdgeInsets.fromLTRB(24.0, 18.0, 24.0, 18.0),
               child: Text(
                 "SlidingUpPanel Example",
-                style: TextStyle(
-                  fontWeight: FontWeight.w500
-                ),
+                style: TextStyle(fontWeight: FontWeight.w500),
               ),
               decoration: BoxDecoration(
                 color: Colors.white,
                 borderRadius: BorderRadius.circular(24.0),
-                boxShadow: [BoxShadow(
-                  color: Color.fromRGBO(0, 0, 0, .25),
-                  blurRadius: 16.0
-                )],
+                boxShadow: [
+                  BoxShadow(
+                    color: Color.fromRGBO(0, 0, 0, .25),
+                    blurRadius: 16.0,
+                  ),
+                ],
               ),
             ),
           ),
-
-
         ],
       ),
     );
   }
 
-  Widget _panel(ScrollController sc){
+  Widget _panel(ScrollController sc) {
     return MediaQuery.removePadding(
       context: context,
       removeTop: true,
       child: ListView(
         controller: sc,
         children: <Widget>[
-          SizedBox(height: 12.0,),
-
+          SizedBox(
+            height: 12.0,
+          ),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -152,15 +154,17 @@ class _HomePageState extends State<HomePage> {
                 width: 30,
                 height: 5,
                 decoration: BoxDecoration(
-                color: Colors.grey[300],
-                  borderRadius: BorderRadius.all(Radius.circular(12.0))
+                  color: Colors.grey[300],
+                  borderRadius: BorderRadius.all(
+                    Radius.circular(12.0),
+                  ),
                 ),
               ),
             ],
           ),
-
-          SizedBox(height: 18.0,),
-
+          SizedBox(
+            height: 18.0,
+          ),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -173,9 +177,9 @@ class _HomePageState extends State<HomePage> {
               ),
             ],
           ),
-
-          SizedBox(height: 36.0,),
-
+          SizedBox(
+            height: 36.0,
+          ),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: <Widget>[
@@ -185,54 +189,60 @@ class _HomePageState extends State<HomePage> {
               _button("More", Icons.more_horiz, Colors.green),
             ],
           ),
-
-          SizedBox(height: 36.0,),
-
+          SizedBox(
+            height: 36.0,
+          ),
           Container(
             padding: const EdgeInsets.only(left: 24.0, right: 24.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-
-                Text("Images", style: TextStyle(fontWeight: FontWeight.w600,)),
-
-                SizedBox(height: 12.0,),
-
+                Text(
+                  "Images",
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                SizedBox(
+                  height: 12.0,
+                ),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: <Widget>[
-
-                      CachedNetworkImage(
-                        imageUrl: "https://images.fineartamerica.com/images-medium-large-5/new-pittsburgh-emmanuel-panagiotakis.jpg",
-                        height: 120.0,
-                        width: (MediaQuery.of(context).size.width - 48) / 2 - 2,
-                        fit: BoxFit.cover,
-                      ),
-
-                      CachedNetworkImage(
-                        imageUrl: "https://cdn.pixabay.com/photo/2016/08/11/23/48/pnc-park-1587285_1280.jpg",
-                        width: (MediaQuery.of(context).size.width - 48) / 2 - 2,
-                        height: 120.0,
-                        fit: BoxFit.cover,
-                      ),
-
+                    CachedNetworkImage(
+                      imageUrl:
+                          "https://images.fineartamerica.com/images-medium-large-5/new-pittsburgh-emmanuel-panagiotakis.jpg",
+                      height: 120.0,
+                      width: (MediaQuery.of(context).size.width - 48) / 2 - 2,
+                      fit: BoxFit.cover,
+                    ),
+                    CachedNetworkImage(
+                      imageUrl:
+                          "https://cdn.pixabay.com/photo/2016/08/11/23/48/pnc-park-1587285_1280.jpg",
+                      width: (MediaQuery.of(context).size.width - 48) / 2 - 2,
+                      height: 120.0,
+                      fit: BoxFit.cover,
+                    ),
                   ],
                 ),
               ],
             ),
           ),
-
-          SizedBox(height: 36.0,),
-
+          SizedBox(
+            height: 36.0,
+          ),
           Container(
             padding: const EdgeInsets.only(left: 24.0, right: 24.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Text("About", style: TextStyle(fontWeight: FontWeight.w600,)),
-
-                SizedBox(height: 12.0,),
-
+                Text("About",
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                    )),
+                SizedBox(
+                  height: 12.0,
+                ),
                 Text(
                   """Pittsburgh is a city in the state of Pennsylvania in the United States, and is the county seat of Allegheny County. A population of about 302,407 (2018) residents live within the city limits, making it the 66th-largest city in the U.S. The metropolitan population of 2,324,743 is the largest in both the Ohio Valley and Appalachia, the second-largest in Pennsylvania (behind Philadelphia), and the 27th-largest in the U.S.\n\nPittsburgh is located in the southwest of the state, at the confluence of the Allegheny, Monongahela, and Ohio rivers. Pittsburgh is known both as "the Steel City" for its more than 300 steel-related businesses and as the "City of Bridges" for its 446 bridges. The city features 30 skyscrapers, two inclined railways, a pre-revolutionary fortification and the Point State Park at the confluence of the rivers. The city developed as a vital link of the Atlantic coast and Midwest, as the mineral-rich Allegheny Mountains made the area coveted by the French and British empires, Virginians, Whiskey Rebels, and Civil War raiders.\n\nAside from steel, Pittsburgh has led in manufacturing of aluminum, glass, shipbuilding, petroleum, foods, sports, transportation, computing, autos, and electronics. For part of the 20th century, Pittsburgh was behind only New York City and Chicago in corporate headquarters employment; it had the most U.S. stockholders per capita. Deindustrialization in the 1970s and 80s laid off area blue-collar workers as steel and other heavy industries declined, and thousands of downtown white-collar workers also lost jobs when several Pittsburgh-based companies moved out. The population dropped from a peak of 675,000 in 1950 to 370,000 in 1990. However, this rich industrial history left the area with renowned museums, medical centers, parks, research centers, and a diverse cultural district.\n\nAfter the deindustrialization of the mid-20th century, Pittsburgh has transformed into a hub for the health care, education, and technology industries. Pittsburgh is a leader in the health care sector as the home to large medical providers such as University of Pittsburgh Medical Center (UPMC). The area is home to 68 colleges and universities, including research and development leaders Carnegie Mellon University and the University of Pittsburgh. Google, Apple Inc., Bosch, Facebook, Uber, Nokia, Autodesk, Amazon, Microsoft and IBM are among 1,600 technology firms generating \$20.7 billion in annual Pittsburgh payrolls. The area has served as the long-time federal agency headquarters for cyber defense, software engineering, robotics, energy research and the nuclear navy. The nation's eighth-largest bank, eight Fortune 500 companies, and six of the top 300 U.S. law firms make their global headquarters in the area, while RAND Corporation (RAND), BNY Mellon, Nova, FedEx, Bayer, and the National Institute for Occupational Safety and Health (NIOSH) have regional bases that helped Pittsburgh become the sixth-best area for U.S. job growth.
                   """,
@@ -241,14 +251,15 @@ class _HomePageState extends State<HomePage> {
               ],
             ),
           ),
-
-          SizedBox(height: 24,),
+          SizedBox(
+            height: 24,
+          ),
         ],
-      )
+      ),
     );
   }
 
-  Widget _button(String label, IconData icon, Color color){
+  Widget _button(String label, IconData icon, Color color) {
     return Column(
       children: <Widget>[
         Container(
@@ -260,22 +271,23 @@ class _HomePageState extends State<HomePage> {
           decoration: BoxDecoration(
             color: color,
             shape: BoxShape.circle,
-            boxShadow: [BoxShadow(
-              color: Color.fromRGBO(0, 0, 0, 0.15),
-              blurRadius: 8.0,
-            )]
+            boxShadow: [
+              BoxShadow(
+                color: Color.fromRGBO(0, 0, 0, 0.15),
+                blurRadius: 8.0,
+              )
+            ],
           ),
         ),
-
-        SizedBox(height: 12.0,),
-
+        SizedBox(
+          height: 12.0,
+        ),
         Text(label),
       ],
-
     );
   }
 
-  Widget _body(){
+  Widget _body() {
     return FlutterMap(
       options: MapOptions(
         center: LatLng(40.441589, -80.010948),
@@ -284,9 +296,8 @@ class _HomePageState extends State<HomePage> {
       ),
       layers: [
         TileLayerOptions(
-          urlTemplate: "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png"
+          urlTemplate: "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png",
         ),
-
         MarkerLayerOptions(
           markers: [
             Marker(
@@ -296,9 +307,9 @@ class _HomePageState extends State<HomePage> {
                 color: Colors.blue,
                 size: 48.0,
               ),
-              height: 60
+              height: 60,
             ),
-          ]
+          ],
         ),
       ],
     );

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -245,106 +245,99 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
               : Alignment.topCenter,
           children: <Widget>[
             //make the back widget take up the entire back side
-            widget.body != null
-                ? Positioned(
-                    top: widget.parallaxEnabled ? _getParallax() : 0.0,
-                    child: Container(
-                      height: constraints.maxHeight,
-                      width: constraints.maxWidth,
-                      child: widget.body,
-                    ),
-                  )
-                : Container(),
+            if (widget.body != null)
+              Positioned(
+                top: widget.parallaxEnabled ? _getParallax() : 0.0,
+                child: Container(
+                  height: constraints.maxHeight,
+                  width: constraints.maxWidth,
+                  child: widget.body,
+                ),
+              ),
 
             //the backdrop to overlay on the body
-            !widget.backdropEnabled
-                ? Container()
-                : GestureDetector(
-                    onTap: widget.backdropTapClosesPanel ? _close : null,
-                    child: FadeTransition(
-                      opacity: Tween(begin: 0.0, end: widget.backdropOpacity)
-                          .animate(_ac),
-                      child: Container(
-                        height: constraints.maxHeight,
-                        width: constraints.maxWidth,
+            if (widget.backdropEnabled)
+              GestureDetector(
+                onTap: widget.backdropTapClosesPanel ? _close : null,
+                child: FadeTransition(
+                  opacity: Tween(begin: 0.0, end: widget.backdropOpacity)
+                      .animate(_ac),
+                  child: Container(
+                    height: constraints.maxHeight,
+                    width: constraints.maxWidth,
 
-                        //set color to null so that touch events pass through
-                        //to the body when the panel is closed, otherwise,
-                        //if a color exists, then touch events won't go through
-                        color: _ac.value == 0.0 ? null : widget.backdropColor,
-                      ),
-                    ),
+                    //set color to null so that touch events pass through
+                    //to the body when the panel is closed, otherwise,
+                    //if a color exists, then touch events won't go through
+                    color: _ac.value == 0.0 ? null : widget.backdropColor,
                   ),
+                ),
+              ),
 
             //the actual sliding part
-            !_isPanelVisible
-                ? Container()
-                : _gestureHandler(
-                    child: Container(
-                      height:
-                          _ac.value * (widget.maxHeight - widget.minHeight) +
-                              widget.minHeight,
-                      margin: widget.margin,
-                      padding: widget.padding,
-                      decoration: widget.renderPanelSheet
-                          ? BoxDecoration(
-                              border: widget.border,
-                              borderRadius: widget.borderRadius,
-                              boxShadow: widget.boxShadow,
-                              color: widget.color,
-                            )
-                          : null,
-                      child: Stack(
-                        children: <Widget>[
-                          //open panel
-                          Positioned(
-                            top: widget.slideDirection == SlideDirection.UP
-                                ? 0.0
-                                : null,
-                            bottom: widget.slideDirection == SlideDirection.DOWN
-                                ? 0.0
-                                : null,
-                            width: constraints.maxWidth -
-                                (widget.margin?.horizontal ?? 0) -
-                                (widget.padding?.horizontal ?? 0),
-                            child: Container(
-                              height: widget.maxHeight,
-                              child: widget.panel != null
-                                  ? widget.panel
-                                  : widget.panelBuilder(_sc),
-                            ),
-                          ),
-
-                          // collapsed panel
-                          Positioned(
-                            top: widget.slideDirection == SlideDirection.UP
-                                ? 0.0
-                                : null,
-                            bottom: widget.slideDirection == SlideDirection.DOWN
-                                ? 0.0
-                                : null,
-                            width: constraints.maxWidth -
-                                (widget.margin?.horizontal ?? 0) -
-                                (widget.padding?.horizontal ?? 0),
-                            child: Container(
-                              height: widget.minHeight,
-                              child: FadeTransition(
-                                opacity:
-                                    Tween(begin: 1.0, end: 0.0).animate(_ac),
-
-                                // if the panel is open ignore pointers (touch events) on the collapsed
-                                // child so that way touch events go through to whatever is underneath
-                                child: IgnorePointer(
-                                  ignoring: _isPanelOpen,
-                                  child: widget.collapsed ?? Container(),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
+            if (_isPanelVisible)
+              _gestureHandler(
+                child: Container(
+                  height: _ac.value * (widget.maxHeight - widget.minHeight) +
+                      widget.minHeight,
+                  margin: widget.margin,
+                  padding: widget.padding,
+                  decoration: widget.renderPanelSheet
+                      ? BoxDecoration(
+                          border: widget.border,
+                          borderRadius: widget.borderRadius,
+                          boxShadow: widget.boxShadow,
+                          color: widget.color,
+                        )
+                      : null,
+                  child: Stack(
+                    children: <Widget>[
+                      //open panel
+                      Positioned(
+                        top: widget.slideDirection == SlideDirection.UP
+                            ? 0.0
+                            : null,
+                        bottom: widget.slideDirection == SlideDirection.DOWN
+                            ? 0.0
+                            : null,
+                        width: constraints.maxWidth -
+                            (widget.margin?.horizontal ?? 0) -
+                            (widget.padding?.horizontal ?? 0),
+                        child: Container(
+                          height: widget.maxHeight,
+                          child: widget.panel ?? widget.panelBuilder(_sc),
+                        ),
                       ),
-                    ),
+
+                      // collapsed panel
+                      Positioned(
+                        top: widget.slideDirection == SlideDirection.UP
+                            ? 0.0
+                            : null,
+                        bottom: widget.slideDirection == SlideDirection.DOWN
+                            ? 0.0
+                            : null,
+                        width: constraints.maxWidth -
+                            (widget.margin?.horizontal ?? 0) -
+                            (widget.padding?.horizontal ?? 0),
+                        child: Container(
+                          height: widget.minHeight,
+                          child: FadeTransition(
+                            opacity: Tween(begin: 1.0, end: 0.0).animate(_ac),
+
+                            // if the panel is open ignore pointers (touch events) on the collapsed
+                            // child so that way touch events go through to whatever is underneath
+                            child: IgnorePointer(
+                              ignoring: _isPanelOpen,
+                              child: widget.collapsed ?? Container(),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -9,18 +9,14 @@ Licensing: More information can be found here: https://github.com/akshathjain/sl
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
-enum SlideDirection{
+enum SlideDirection {
   UP,
   DOWN,
 }
 
-enum PanelState{
-  OPEN,
-  CLOSED
-}
+enum PanelState { OPEN, CLOSED }
 
 class SlidingUpPanel extends StatefulWidget {
-
   /// The Widget that slides into view. When the
   /// panel is collapsed and if [collapsed] is null,
   /// then top portion of this Widget will be displayed;
@@ -175,16 +171,16 @@ class SlidingUpPanel extends StatefulWidget {
     this.isDraggable = true,
     this.slideDirection = SlideDirection.UP,
     this.defaultPanelState = PanelState.CLOSED,
-  }) : assert(panel != null || panelBuilder != null),
-       assert(0 <= backdropOpacity && backdropOpacity <= 1.0),
-       super(key: key);
+  })  : assert(panel != null || panelBuilder != null),
+        assert(0 <= backdropOpacity && backdropOpacity <= 1.0),
+        super(key: key);
 
   @override
   _SlidingUpPanelState createState() => _SlidingUpPanelState();
 }
 
-class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProviderStateMixin{
-
+class _SlidingUpPanelState extends State<SlidingUpPanel>
+    with SingleTickerProviderStateMixin {
   AnimationController _ac;
 
   ScrollController _sc;
@@ -194,148 +190,177 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   bool _isPanelVisible = true;
 
   @override
-  void initState(){
+  void initState() {
     super.initState();
 
     _ac = new AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 300),
-      value: widget.defaultPanelState == PanelState.CLOSED ? 0.0 : 1.0 //set the default panel state (i.e. set initial value of _ac)
-    )..addListener((){
-      setState((){});
+        vsync: this,
+        duration: const Duration(milliseconds: 300),
+        value: widget.defaultPanelState == PanelState.CLOSED
+            ? 0.0
+            : 1.0 //set the default panel state (i.e. set initial value of _ac)
+        )
+      ..addListener(() {
+        setState(() {});
 
-      if(widget.onPanelSlide != null) widget.onPanelSlide(_ac.value);
+        if (widget.onPanelSlide != null) widget.onPanelSlide(_ac.value);
 
-      if(widget.onPanelOpened != null && _ac.value == 1.0) widget.onPanelOpened();
+        if (widget.onPanelOpened != null && _ac.value == 1.0)
+          widget.onPanelOpened();
 
-      if(widget.onPanelClosed != null && _ac.value == 0.0) widget.onPanelClosed();
-    });
+        if (widget.onPanelClosed != null && _ac.value == 0.0)
+          widget.onPanelClosed();
+      });
 
     _sc = new ScrollController();
 
     // prevent the panel content from being scrolled only if the widget is
     // draggable and panel scrolling is enabled
-    _sc.addListener((){
-      if(widget.isDraggable && !_scrollingEnabled)
-        _sc.jumpTo(0);
+    _sc.addListener(() {
+      if (widget.isDraggable && !_scrollingEnabled) _sc.jumpTo(0);
     });
 
     widget.controller?._addState(
-      // _close,
-      // _open,
-      // _hide,
-      // _show,
-      // _setPanelPosition,
-      // _animatePanelToPosition,
-      // _getPanelPosition,
-      // _isPanelAnimating,
-      // _isPanelOpen,
-      // _isPanelClosed,
-      // _isPanelShown,
-      this
-    );
+        // _close,
+        // _open,
+        // _hide,
+        // _show,
+        // _setPanelPosition,
+        // _animatePanelToPosition,
+        // _getPanelPosition,
+        // _isPanelAnimating,
+        // _isPanelOpen,
+        // _isPanelClosed,
+        // _isPanelShown,
+        this);
   }
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: widget.slideDirection == SlideDirection.UP ? Alignment.bottomCenter : Alignment.topCenter,
-      children: <Widget>[
-
-
-        //make the back widget take up the entire back side
-        widget.body != null ? Positioned(
-          top: widget.parallaxEnabled ? _getParallax() : 0.0,
-          child: Container(
-            height: MediaQuery.of(context).size.height,
-            width: MediaQuery.of(context).size.width,
-            child: widget.body,
-          ),
-        ) : Container(),
-
-
-        //the backdrop to overlay on the body
-        !widget.backdropEnabled ? Container() : GestureDetector(
-          onTap: widget.backdropTapClosesPanel ? _close : null,
-          child: FadeTransition(
-            opacity: Tween(begin: 0.0, end: widget.backdropOpacity).animate(_ac),
-            child: Container(
-              height: MediaQuery.of(context).size.height,
-              width: MediaQuery.of(context).size.width,
-
-              //set color to null so that touch events pass through
-              //to the body when the panel is closed, otherwise,
-              //if a color exists, then touch events won't go through
-              color: _ac.value == 0.0 ? null : widget.backdropColor,
-            ),
-          ),
-        ),
-
-
-        //the actual sliding part
-        !_isPanelVisible ? Container() : _gestureHandler(
-          child: Container(
-            height: _ac.value * (widget.maxHeight - widget.minHeight) + widget.minHeight,
-            margin: widget.margin,
-            padding: widget.padding,
-            decoration: widget.renderPanelSheet ? BoxDecoration(
-              border: widget.border,
-              borderRadius: widget.borderRadius,
-              boxShadow: widget.boxShadow,
-              color: widget.color,
-            ) : null,
-            child: Stack(
-              children: <Widget>[
-
-                //open panel
-                Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin.horizontal : 0) -
-                          (widget.padding != null ? widget.padding.horizontal : 0),
-                  child: Container(
-                    height: widget.maxHeight,
-                    child: widget.panel != null
-                            ? widget.panel
-                            : widget.panelBuilder(_sc),
+    return SizedBox.expand(
+      child: LayoutBuilder(
+        builder: (context, constraints) => Stack(
+          alignment: widget.slideDirection == SlideDirection.UP
+              ? Alignment.bottomCenter
+              : Alignment.topCenter,
+          children: <Widget>[
+            //make the back widget take up the entire back side
+            widget.body != null
+                ? Positioned(
+                    top: widget.parallaxEnabled ? _getParallax() : 0.0,
+                    child: Container(
+                      height: constraints.maxHeight,
+                      width: constraints.maxWidth,
+                      child: widget.body,
+                    ),
                   )
-                ),
+                : Container(),
 
-                // collapsed panel
-                Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin.horizontal : 0) -
-                          (widget.padding != null ? widget.padding.horizontal : 0),
-                  child: Container(
-                    height: widget.minHeight,
+            //the backdrop to overlay on the body
+            !widget.backdropEnabled
+                ? Container()
+                : GestureDetector(
+                    onTap: widget.backdropTapClosesPanel ? _close : null,
                     child: FadeTransition(
-                      opacity: Tween(begin: 1.0, end: 0.0).animate(_ac),
+                      opacity: Tween(begin: 0.0, end: widget.backdropOpacity)
+                          .animate(_ac),
+                      child: Container(
+                        height: constraints.maxHeight,
+                        width: constraints.maxWidth,
 
-                      // if the panel is open ignore pointers (touch events) on the collapsed
-                      // child so that way touch events go through to whatever is underneath
-                      child: IgnorePointer(
-                        ignoring: _isPanelOpen,
-                        child: widget.collapsed ?? Container(),
+                        //set color to null so that touch events pass through
+                        //to the body when the panel is closed, otherwise,
+                        //if a color exists, then touch events won't go through
+                        color: _ac.value == 0.0 ? null : widget.backdropColor,
                       ),
                     ),
                   ),
-                ),
 
+            //the actual sliding part
+            !_isPanelVisible
+                ? Container()
+                : _gestureHandler(
+                    child: Container(
+                      height:
+                          _ac.value * (widget.maxHeight - widget.minHeight) +
+                              widget.minHeight,
+                      margin: widget.margin,
+                      padding: widget.padding,
+                      decoration: widget.renderPanelSheet
+                          ? BoxDecoration(
+                              border: widget.border,
+                              borderRadius: widget.borderRadius,
+                              boxShadow: widget.boxShadow,
+                              color: widget.color,
+                            )
+                          : null,
+                      child: Stack(
+                        children: <Widget>[
+                          //open panel
+                          Positioned(
+                              top: widget.slideDirection == SlideDirection.UP
+                                  ? 0.0
+                                  : null,
+                              bottom:
+                                  widget.slideDirection == SlideDirection.DOWN
+                                      ? 0.0
+                                      : null,
+                              width: constraints.maxWidth -
+                                  (widget.margin != null
+                                      ? widget.margin.horizontal
+                                      : 0) -
+                                  (widget.padding != null
+                                      ? widget.padding.horizontal
+                                      : 0),
+                              child: Container(
+                                height: widget.maxHeight,
+                                child: widget.panel != null
+                                    ? widget.panel
+                                    : widget.panelBuilder(_sc),
+                              )),
 
-              ],
-            ),
-          ),
+                          // collapsed panel
+                          Positioned(
+                            top: widget.slideDirection == SlideDirection.UP
+                                ? 0.0
+                                : null,
+                            bottom: widget.slideDirection == SlideDirection.DOWN
+                                ? 0.0
+                                : null,
+                            width: constraints.maxWidth -
+                                (widget.margin != null
+                                    ? widget.margin.horizontal
+                                    : 0) -
+                                (widget.padding != null
+                                    ? widget.padding.horizontal
+                                    : 0),
+                            child: Container(
+                              height: widget.minHeight,
+                              child: FadeTransition(
+                                opacity:
+                                    Tween(begin: 1.0, end: 0.0).animate(_ac),
+
+                                // if the panel is open ignore pointers (touch events) on the collapsed
+                                // child so that way touch events go through to whatever is underneath
+                                child: IgnorePointer(
+                                  ignoring: _isPanelOpen,
+                                  child: widget.collapsed ?? Container(),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+          ],
         ),
-
-      ],
+      ),
     );
   }
 
   @override
-  void dispose(){
+  void dispose() {
     _ac.dispose();
     super.dispose();
   }
@@ -344,20 +369,23 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   // and a listener if panelBuilder is used.
   // this is because the listener is designed only for use with linking the scrolling of
   // panels and using it for panels that don't want to linked scrolling yields odd results
-  Widget _gestureHandler({Widget child}){
+  Widget _gestureHandler({Widget child}) {
     if (!widget.isDraggable) return child;
 
-    if (widget.panel != null){
+    if (widget.panel != null) {
       return GestureDetector(
-        onVerticalDragUpdate: (DragUpdateDetails dets) => _onGestureSlide(dets.delta.dy),
-        onVerticalDragEnd: (DragEndDetails dets) => _onGestureEnd(dets.velocity),
+        onVerticalDragUpdate: (DragUpdateDetails dets) =>
+            _onGestureSlide(dets.delta.dy),
+        onVerticalDragEnd: (DragEndDetails dets) =>
+            _onGestureEnd(dets.velocity),
         child: child,
       );
     }
 
     return Listener(
-      onPointerMove: (PointerMoveEvent p){
-        _vt.addPosition(p.timeStamp, p.position); // add current position for velocity tracking
+      onPointerMove: (PointerMoveEvent p) {
+        _vt.addPosition(p.timeStamp,
+            p.position); // add current position for velocity tracking
         _onGestureSlide(p.delta.dy);
       },
       onPointerUp: (PointerUpEvent p) => _onGestureEnd(_vt.getVelocity()),
@@ -365,20 +393,22 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
     );
   }
 
-
-  double _getParallax(){
-    if(widget.slideDirection == SlideDirection.UP)
-      return -_ac.value * (widget.maxHeight - widget.minHeight) * widget.parallaxOffset;
+  double _getParallax() {
+    if (widget.slideDirection == SlideDirection.UP)
+      return -_ac.value *
+          (widget.maxHeight - widget.minHeight) *
+          widget.parallaxOffset;
     else
-      return _ac.value * (widget.maxHeight - widget.minHeight) * widget.parallaxOffset;
+      return _ac.value *
+          (widget.maxHeight - widget.minHeight) *
+          widget.parallaxOffset;
   }
 
   // handles the sliding gesture
-  void _onGestureSlide(double dy){
-
+  void _onGestureSlide(double dy) {
     // only slide the panel if scrolling is not enabled
-    if(!_scrollingEnabled){
-      if(widget.slideDirection == SlideDirection.UP)
+    if (!_scrollingEnabled) {
+      if (widget.slideDirection == SlideDirection.UP)
         _ac.value -= dy / (widget.maxHeight - widget.minHeight);
       else
         _ac.value += dy / (widget.maxHeight - widget.minHeight);
@@ -387,11 +417,11 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
     // if the panel is open and the user hasn't scrolled, we need to determine
     // whether to enable scrolling if the user swipes up, or disable closing and
     // begin to close the panel if the user swipes down
-    if(_isPanelOpen && _sc.hasClients && _sc.offset <= 0){
+    if (_isPanelOpen && _sc.hasClients && _sc.offset <= 0) {
       setState(() {
-        if(dy < 0){
+        if (dy < 0) {
           _scrollingEnabled = true;
-        }else{
+        } else {
           _scrollingEnabled = false;
         }
       });
@@ -399,26 +429,27 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   }
 
   // handles when user stops sliding
-  void _onGestureEnd(Velocity velocity){
+  void _onGestureEnd(Velocity velocity) {
     double minFlingVelocity = 365.0;
 
     //let the current animation finish before starting a new one
-    if(_ac.isAnimating) return;
+    if (_ac.isAnimating) return;
 
     // if scrolling is allowed and the panel is open, we don't want to close
     // the panel if they swipe up on the scrollable
-    if(_isPanelOpen && _scrollingEnabled) return;
+    if (_isPanelOpen && _scrollingEnabled) return;
 
     //check if the velocity is sufficient to constitute fling
-    if(velocity.pixelsPerSecond.dy.abs() >= minFlingVelocity){
-      double visualVelocity = - velocity.pixelsPerSecond.dy / (widget.maxHeight - widget.minHeight);
+    if (velocity.pixelsPerSecond.dy.abs() >= minFlingVelocity) {
+      double visualVelocity =
+          -velocity.pixelsPerSecond.dy / (widget.maxHeight - widget.minHeight);
 
-      if(widget.slideDirection == SlideDirection.DOWN)
+      if (widget.slideDirection == SlideDirection.DOWN)
         visualVelocity = -visualVelocity;
 
-      if(widget.panelSnapping){
+      if (widget.panelSnapping) {
         _ac.fling(velocity: visualVelocity);
-      }else{
+      } else {
         // actual scroll physics will be implemented in a future release
         _ac.animateTo(
           _ac.value + visualVelocity * 0.16,
@@ -432,12 +463,11 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
     // check if the controller is already halfway there
     if (widget.panelSnapping) {
-      if(_ac.value > 0.5)
+      if (_ac.value > 0.5)
         _open();
       else
         _close();
     }
-
   }
 
   //---------------------------------
@@ -445,18 +475,18 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   //---------------------------------
 
   //close the panel
-  Future<void> _close(){
+  Future<void> _close() {
     return _ac.fling(velocity: -1.0);
   }
 
   //open the panel
-  Future<void> _open(){
+  Future<void> _open() {
     return _ac.fling(velocity: 1.0);
   }
 
   //hide the panel (completely offscreen)
-  Future<void> _hide(){
-    return _ac.fling(velocity: -1.0).then((x){
+  Future<void> _hide() {
+    return _ac.fling(velocity: -1.0).then((x) {
       setState(() {
         _isPanelVisible = false;
       });
@@ -464,8 +494,8 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   }
 
   //show the panel (in collapsed mode)
-  Future<void> _show(){
-    return _ac.fling(velocity: -1.0).then((x){
+  Future<void> _show() {
+    return _ac.fling(velocity: -1.0).then((x) {
       setState(() {
         _isPanelVisible = true;
       });
@@ -474,14 +504,14 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
   //set the panel position to value - must
   //be between 0.0 and 1.0
-  Future<void> _animatePanelToPosition(double value){
+  Future<void> _animatePanelToPosition(double value) {
     assert(0.0 <= value && value <= 1.0);
     return _ac.animateTo(value);
   }
 
   //set the panel position to value - must
   //be between 0.0 and 1.0
-  set _panelPosition(double value){
+  set _panelPosition(double value) {
     assert(0.0 <= value && value <= 1.0);
     _ac.value = value;
   }
@@ -506,20 +536,12 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   //returns whether or not the
   //panel is shown/hidden
   bool get _isPanelShown => _isPanelVisible;
-
 }
 
-
-
-
-
-
-
-
-class PanelController{
+class PanelController {
   _SlidingUpPanelState _panelState;
 
-  void _addState(_SlidingUpPanelState panelState){
+  void _addState(_SlidingUpPanelState panelState) {
     this._panelState = panelState;
   }
 
@@ -529,27 +551,27 @@ class PanelController{
   bool get isAttached => _panelState != null;
 
   /// Closes the sliding panel to its collapsed state (i.e. to the  minHeight)
-  Future<void> close(){
+  Future<void> close() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._close();
   }
 
   /// Opens the sliding panel fully
   /// (i.e. to the maxHeight)
-  Future<void> open(){
+  Future<void> open() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._open();
   }
 
   /// Hides the sliding panel (i.e. is invisible)
-  Future<void> hide(){
+  Future<void> hide() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._hide();
   }
 
   /// Shows the sliding panel in its collapsed state
   /// (i.e. "un-hide" the sliding panel)
-  Future<void> show(){
+  Future<void> show() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._show();
   }
@@ -557,7 +579,7 @@ class PanelController{
   /// Animates the panel position to the value.
   /// The value must between 0.0 and 1.0
   /// where 0.0 is fully collapsed and 1.0 is completely open
-  Future<void> animatePanelToPosition(double value){
+  Future<void> animatePanelToPosition(double value) {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     assert(0.0 <= value && value <= 1.0);
     return _panelState._animatePanelToPosition(value);
@@ -566,7 +588,7 @@ class PanelController{
   /// Sets the panel position (without animation).
   /// The value must between 0.0 and 1.0
   /// where 0.0 is fully collapsed and 1.0 is completely open.
-  set panelPosition(double value){
+  set panelPosition(double value) {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     assert(0.0 <= value && value <= 1.0);
     _panelState._panelPosition = value;
@@ -578,37 +600,36 @@ class PanelController{
   /// as a decimal between 0.0 and 1.0
   /// where 0.0 is fully collapsed and
   /// 1.0 is full open.
-  double get panelPosition{
+  double get panelPosition {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._panelPosition;
   }
 
   /// Returns whether or not the panel is
   /// currently animating.
-  bool get isPanelAnimating{
+  bool get isPanelAnimating {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._isPanelAnimating;
   }
 
   /// Returns whether or not the
   /// panel is open.
-  bool get isPanelOpen{
+  bool get isPanelOpen {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._isPanelOpen;
   }
 
   /// Returns whether or not the
   /// panel is closed.
-  bool get isPanelClosed{
+  bool get isPanelClosed {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._isPanelClosed;
   }
 
   /// Returns whether or not the
   /// panel is shown/hidden.
-  bool get isPanelShown{
+  bool get isPanelShown {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState._isPanelShown;
   }
-
 }

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -185,7 +185,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
 
   ScrollController _sc;
   bool _scrollingEnabled = false;
-  VelocityTracker _vt = new VelocityTracker();
+  VelocityTracker _vt = VelocityTracker();
 
   bool _isPanelVisible = true;
 
@@ -193,7 +193,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
   void initState() {
     super.initState();
 
-    _ac = new AnimationController(
+    _ac = AnimationController(
         vsync: this,
         duration: const Duration(milliseconds: 300),
         value: widget.defaultPanelState == PanelState.CLOSED
@@ -212,7 +212,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
           widget.onPanelClosed();
       });
 
-    _sc = new ScrollController();
+    _sc = ScrollController();
 
     // prevent the panel content from being scrolled only if the widget is
     // draggable and panel scrolling is enabled
@@ -298,26 +298,22 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
                         children: <Widget>[
                           //open panel
                           Positioned(
-                              top: widget.slideDirection == SlideDirection.UP
-                                  ? 0.0
-                                  : null,
-                              bottom:
-                                  widget.slideDirection == SlideDirection.DOWN
-                                      ? 0.0
-                                      : null,
-                              width: constraints.maxWidth -
-                                  (widget.margin != null
-                                      ? widget.margin.horizontal
-                                      : 0) -
-                                  (widget.padding != null
-                                      ? widget.padding.horizontal
-                                      : 0),
-                              child: Container(
-                                height: widget.maxHeight,
-                                child: widget.panel != null
-                                    ? widget.panel
-                                    : widget.panelBuilder(_sc),
-                              )),
+                            top: widget.slideDirection == SlideDirection.UP
+                                ? 0.0
+                                : null,
+                            bottom: widget.slideDirection == SlideDirection.DOWN
+                                ? 0.0
+                                : null,
+                            width: constraints.maxWidth -
+                                (widget.margin?.horizontal ?? 0) -
+                                (widget.padding?.horizontal ?? 0),
+                            child: Container(
+                              height: widget.maxHeight,
+                              child: widget.panel != null
+                                  ? widget.panel
+                                  : widget.panelBuilder(_sc),
+                            ),
+                          ),
 
                           // collapsed panel
                           Positioned(
@@ -328,12 +324,8 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
                                 ? 0.0
                                 : null,
                             width: constraints.maxWidth -
-                                (widget.margin != null
-                                    ? widget.margin.horizontal
-                                    : 0) -
-                                (widget.padding != null
-                                    ? widget.padding.horizontal
-                                    : 0),
+                                (widget.margin?.horizontal ?? 0) -
+                                (widget.padding?.horizontal ?? 0),
                             child: Container(
                               height: widget.minHeight,
                               child: FadeTransition(

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -137,7 +137,7 @@ class SlidingUpPanel extends StatefulWidget {
   /// by default the Panel is open and must be swiped closed by the user.
   final PanelState defaultPanelState;
 
-  SlidingUpPanel({
+  const SlidingUpPanel({
     Key key,
     this.panel,
     this.panelBuilder,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/akshathjain/sliding_up_panel
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR includes basicly the same improvement like #64 but i need to make a new one because git destroyed my fork.

With this PR I improve the layout so that sliding_up_panel now can limited to a specific part of the screen or size.
As Example:
Now it is possible to create a master detail layout with sliding_up_panel on the detail part.

Also I bump the Dart SDK version to 2.3.0 to use collection if which improves the code quality as same as small other improvements I've done