### PR TITLE
Change backdrop closing to use onTapDown rather than onTap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Flutter Version [e.g. 1.12.13]
+ - sliding_up_panel Version [e.g. 1.0.0]
+
+**Additional context**
+Add any other context about the problem here.
+
+**Sample `main.dart`**
+Please provide a sample `main.dart` that reproduces this issue.
+```
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,16 +19,16 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
+**Additional context**
+Add any other context about the problem here.
+
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Flutter Version [e.g. 1.12.13]
  - sliding_up_panel Version [e.g. 1.0.0]
 
-**Additional context**
-Add any other context about the problem here.
-
 **Sample `main.dart`**
-Please provide a sample `main.dart` that reproduces this issue.
+Please provide a sample `main.dart` that reproduces this issue. The code provided here should be able to be run on its own without any external dependencies.
 ```
 ```

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -256,7 +256,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
         //the backdrop to overlay on the body
         !widget.backdropEnabled ? Container() : GestureDetector(
-          onTap: widget.backdropTapClosesPanel ? _close : null,
+          onTapDown: widget.backdropTapClosesPanel ? (_) => _close() : null,
           child: FadeTransition(
             opacity: Tween(begin: 0.0, end: widget.backdropOpacity).animate(_ac),
             child: Container(


### PR DESCRIPTION
Right now, the GestureDetector for the backdrop uses onTap for detecting when the panel should be closed. Unfortunately this means that downward swipes in the backdrop--a natural user gesture--don't behave as expected, leaving the panel open still.

By using onTapDown, any gesture, including a swipe and a tap, will effectively close the panel.

Thanks!