### PR TITLE
Added screen reader support, if backdropEnabled is true.

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -271,27 +271,29 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
 
         //the backdrop to overlay on the body
-        !widget.backdropEnabled ? Container() : GestureDetector(
-          onVerticalDragEnd: widget.backdropTapClosesPanel ? (DragEndDetails dets){
-            // only trigger a close if the drag is towards panel close position
-            if((widget.slideDirection == SlideDirection.UP ? 1 : -1) * dets.velocity.pixelsPerSecond.dy > 0)
-              _close();
-          } : null,
-          onTap: widget.backdropTapClosesPanel ? () => _close() : null,
-          child: AnimatedBuilder(
-            animation: _ac,
-            builder: (context, _) {
-              return Container(
-                height: MediaQuery.of(context).size.height,
-                width: MediaQuery.of(context).size.width,
+        !widget.backdropEnabled ? Container() : ExcludeSemantics(
+            child: GestureDetector(
+              onVerticalDragEnd: widget.backdropTapClosesPanel ? (DragEndDetails dets){
+                // only trigger a close if the drag is towards panel close position
+                if((widget.slideDirection == SlideDirection.UP ? 1 : -1) * dets.velocity.pixelsPerSecond.dy > 0)
+                  _close();
+              } : null,
+              onTap: widget.backdropTapClosesPanel ? () => _close() : null,
+              child: AnimatedBuilder(
+                animation: _ac,
+                builder: (context, _) {
+                  return Container(
+                    height: MediaQuery.of(context).size.height,
+                    width: MediaQuery.of(context).size.width,
 
-                //set color to null so that touch events pass through
-                //to the body when the panel is closed, otherwise,
-                //if a color exists, then touch events won't go through
-                color: _ac.value == 0.0 ? null : widget.backdropColor.withOpacity(widget.backdropOpacity * _ac.value),
-              );
-            }
-          ),
+                      //set color to null so that touch events pass through
+                      //to the body when the panel is closed, otherwise,
+                      //if a color exists, then touch events won't go through
+                      color: _ac.value == 0.0 ? null : widget.backdropColor.withOpacity(widget.backdropOpacity * _ac.value),
+                    );
+                  }
+              ),
+            ),
         ),
 
 


### PR DESCRIPTION
## Description
As I showed in #168 `backdropEnabled == true` breaks the app for screen readers. This is very critical... 

## What was the problem?
The problem was, that `GestureDetector ` already have a `Semantics` widget included. The backdrop takes up all the space. Because of this a screen reader tried every time to read the backdrop instead of the real content of the app. 

## Solution
The solution is to use `ExcludeSemantics`, which ignores all `Semantics` in the widget tree.