### PR TITLE
Added AnimationController to PanelController

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -612,6 +612,9 @@ class PanelController{
     this._panelState = panelState;
   }
 
+  /// Returns the used animationController
+  AnimationController get animationController => _panelState._ac;
+
   /// Determine if the panelController is attached to an instance
   /// of the SlidingUpPanel (this property must return true before any other
   /// functions can be used)


### PR DESCRIPTION
## Description
Sometimes it's very helpful to access the `AnimationController`, to do some animations, if the user opens the panel. This PR gives access to `AnimationController` via `PanelController`.

## Try it out
Until this PR isn't merged, you can use this in your `pubspec.yaml`:

```
sliding_up_panel: 
   git: 
     url: https://github.com/AndroidNils/sliding_up_panel 
     ref: animation-controller
```