### PR TITLE
fixed #68 by adding Overflow.visible to stack

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -249,6 +249,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   @override
   Widget build(BuildContext context) {
     return Stack(
+      overflow: Overflow.visible,
       alignment: widget.slideDirection == SlideDirection.UP ? Alignment.bottomCenter : Alignment.topCenter,
       children: <Widget>[
 


### PR DESCRIPTION
Fixes #68 by adding `Overflow.visible` to the main Stack. Tested and confirmed that it fixes the bug with Google Maps for me! Please give it a try.