### PR TITLE
Fix exception when panelBuilder ScrollController attached to multiple views & SafeArea on iPhones

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ There are several options that allow for more control:
 | `isDraggable` | Allows toggling of draggability of the SlidingUpPanel. Set this to false to prevent the user from being able to drag the panel up and down. Defaults to true. |
 | `slideDirection` | Either `SlideDirection.UP` or `SlideDirection.DOWN`. Indicates which way the panel should slide. Defaults to `UP`. If set to `DOWN`, the panel attaches itself to the top of the screen and is fully opened when the user swipes down on the panel. |
 | `defaultPanelState` | The default state of the panel; either PanelState.OPEN or `PanelState.CLOSED`. This value defaults to `PanelState.CLOSED` which indicates that the panel is in the closed position and must be opened. `PanelState.OPEN` indicates that by default the Panel is open and must be swiped closed by the user. |
+| `applySafeArea` | Applies `SafeArea` and `LayoutBuilder` widgets to either `panel` or `panelBuilder`. The default value is false. Use this only if you have issues with widgets getting cut off in landscape mode on certain devices, such as iPhones with notches. |
 
 <br>
 <br>

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -430,7 +430,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
     // if the panel is open and the user hasn't scrolled, we need to determine
     // whether to enable scrolling if the user swipes up, or disable closing and
     // begin to close the panel if the user swipes down
-    if(_isPanelOpen && _sc.hasClients && _sc.offset <= 0){
+    if(_isPanelOpen && _sc.hasClients && (_sc.positions.length > 1 || _sc.offset <= 0)){
       setState(() {
         if(dy < 0){
           _scrollingEnabled = true;

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -220,6 +220,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   bool _isPanelVisible = true;
 
   bool shouldSlide = true;
+  bool slideStarted = false;
 
   @override
   void initState(){
@@ -420,10 +421,12 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
       onPointerMove: (PointerMoveEvent p){
         _vt.addPosition(p.timeStamp, p.position);
         // add current position for velocity tracking
-        if (p.delta.dx.abs() > p.delta.dy.abs() && shouldSlide) {
+        if (p.delta.dx.abs() > p.delta.dy.abs() && !slideStarted) {
           shouldSlide = false;
-        } else if (p.delta.dx.abs() < p.delta.dy.abs() && !shouldSlide) {
+          slideStarted = true;
+        } else if (p.delta.dx.abs() < p.delta.dy.abs() && !slideStarted) {
           shouldSlide = true;
+          slideStarted = true;
         }
         if (shouldSlide) {
           _onGestureSlide(p.delta.dy);
@@ -432,8 +435,10 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
       onPointerUp: (PointerUpEvent p) {
         if (shouldSlide) {
           _onGestureEnd(_vt.getVelocity());
+          slideStarted = false;
         } else {
           shouldSlide = true;
+          slideStarted = false;
         }
       },
       child: child,

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -219,6 +219,8 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
   bool _isPanelVisible = true;
 
+  bool shouldSlide = true;
+
   @override
   void initState(){
     super.initState();
@@ -408,10 +410,24 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
     return Listener(
       onPointerDown: (PointerDownEvent p) => _vt.addPosition(p.timeStamp, p.position),
       onPointerMove: (PointerMoveEvent p){
-        _vt.addPosition(p.timeStamp, p.position); // add current position for velocity tracking
-        _onGestureSlide(p.delta.dy);
+        _vt.addPosition(p.timeStamp, p.position);
+        // add current position for velocity tracking
+        if (p.delta.dx.abs() > p.delta.dy.abs() && shouldSlide) {
+          shouldSlide = false;
+        } else if (p.delta.dx.abs() < p.delta.dy.abs() && !shouldSlide) {
+          shouldSlide = true;
+        }
+        if (shouldSlide) {
+          _onGestureSlide(p.delta.dy);
+        }
       },
-      onPointerUp: (PointerUpEvent p) => _onGestureEnd(_vt.getVelocity()),
+      onPointerUp: (PointerUpEvent p) {
+        if (shouldSlide) {
+          _onGestureEnd(_vt.getVelocity());
+        } else {
+          shouldSlide = true;
+        }
+      },
       child: child,
     );
   }

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -248,132 +248,140 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: widget.slideDirection == SlideDirection.UP ? Alignment.bottomCenter : Alignment.topCenter,
-      children: <Widget>[
+    return SafeArea(
+        child: LayoutBuilder(
+            builder: (context, constraints) {
+              return Stack(
+                alignment: widget.slideDirection == SlideDirection.UP ? Alignment.bottomCenter : Alignment.topCenter,
+                children: <Widget>[
 
 
-        //make the back widget take up the entire back side
-        widget.body != null ? AnimatedBuilder(
-          animation: _ac,
-          builder: (context, child){
-            return Positioned(
-              top: widget.parallaxEnabled ? _getParallax() : 0.0,
-              child: child,
-            );
-          },
-          child: Container(
-            height: MediaQuery.of(context).size.height,
-            width: MediaQuery.of(context).size.width,
-            child: widget.body,
-          ),
-        ) : Container(),
+                  //make the back widget take up the entire back side
+                  widget.body != null ? AnimatedBuilder(
+                    animation: _ac,
+                    builder: (context, child){
+                      return Positioned(
+                        top: widget.parallaxEnabled ? _getParallax() : 0.0,
+                        child: child,
+                      );
+                    },
+                    child: Container(
+                      height: MediaQuery.of(context).size.height,
+                      width: constraints.maxWidth,
+                      child: widget.body,
+                    ),
+                  ) : Container(),
 
 
-        //the backdrop to overlay on the body
-        !widget.backdropEnabled ? Container() : GestureDetector(
-          onVerticalDragEnd: widget.backdropTapClosesPanel ? (DragEndDetails dets){
-            // only trigger a close if the drag is towards panel close position
-            if((widget.slideDirection == SlideDirection.UP ? 1 : -1) * dets.velocity.pixelsPerSecond.dy > 0)
-              _close();
-          } : null,
-          onTap: widget.backdropTapClosesPanel ? () => _close() : null,
-          child: AnimatedBuilder(
-            animation: _ac,
-            builder: (context, _) {
-              return Container(
-                height: MediaQuery.of(context).size.height,
-                width: MediaQuery.of(context).size.width,
+                  //the backdrop to overlay on the body
+                  !widget.backdropEnabled ? Container() : GestureDetector(
+                    onVerticalDragEnd: widget.backdropTapClosesPanel ? (DragEndDetails dets){
+                      // only trigger a close if the drag is towards panel close position
+                      if((widget.slideDirection == SlideDirection.UP ? 1 : -1) * dets.velocity.pixelsPerSecond.dy > 0)
+                        _close();
+                    } : null,
+                    onTap: widget.backdropTapClosesPanel ? () => _close() : null,
+                    child: AnimatedBuilder(
+                        animation: _ac,
+                        builder: (context, _) {
+                          return Container(
+                            height: MediaQuery.of(context).size.height,
+                            width: MediaQuery.of(context).size.width,
 
-                //set color to null so that touch events pass through
-                //to the body when the panel is closed, otherwise,
-                //if a color exists, then touch events won't go through
-                color: _ac.value == 0.0 ? null : widget.backdropColor.withOpacity(widget.backdropOpacity * _ac.value),
-              );
-            }
-          ),
-        ),
+                            //set color to null so that touch events pass through
+                            //to the body when the panel is closed, otherwise,
+                            //if a color exists, then touch events won't go through
+                            color: _ac.value == 0.0 ? null : widget.backdropColor.withOpacity(widget.backdropOpacity * _ac.value),
+                          );
+                        }
+                    ),
+                  ),
 
 
-        //the actual sliding part
-        !_isPanelVisible ? Container() : _gestureHandler(
-          child: AnimatedBuilder(
-            animation: _ac,
-            builder: (context, child) {
-              return Container(
-                height: _ac.value * (widget.maxHeight - widget.minHeight) + widget.minHeight,
-                margin: widget.margin,
-                padding: widget.padding,
-                decoration: widget.renderPanelSheet ? BoxDecoration(
-                  border: widget.border,
-                  borderRadius: widget.borderRadius,
-                  boxShadow: widget.boxShadow,
-                  color: widget.color,
-                ) : null,
-                child: child,
-              );
-            },
-            child: Stack(
-              children: <Widget>[
+                  //the actual sliding part
+                  !_isPanelVisible ? Container() : _gestureHandler(
+                    child: AnimatedBuilder(
+                      animation: _ac,
+                      builder: (context, child) {
+                        return Container(
+                          height: _ac.value * (widget.maxHeight - widget.minHeight) + widget.minHeight,
+                          width: constraints.maxWidth,
+                          margin: widget.margin,
+                          padding: widget.padding,
+                          decoration: widget.renderPanelSheet ? BoxDecoration(
+                            border: widget.border,
+                            borderRadius: widget.borderRadius,
+                            boxShadow: widget.boxShadow,
+                            color: widget.color,
+                          ) : null,
+                          child: child,
+                        );
+                      },
+                      child: Stack(
+                        children: <Widget>[
 
-                //open panel
-                Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin.horizontal : 0) -
-                          (widget.padding != null ? widget.padding.horizontal : 0),
-                  child: Container(
-                    height: widget.maxHeight,
-                    child: widget.panel != null
-                            ? widget.panel
-                            : widget.panelBuilder(_sc),
-                  )
-                ),
+                          //open panel
+                          Positioned(
+                              top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
+                              bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
+                              width:  constraints.maxWidth -
+                                  (widget.margin != null ? widget.margin.horizontal : 0) -
+                                  (widget.padding != null ? widget.padding.horizontal : 0),
+                              child: Container(
+                                height: widget.maxHeight,
+                                width: constraints.maxWidth,
+                                child: widget.panel != null
+                                    ? widget.panel
+                                    : widget.panelBuilder(_sc),
+                              )
+                          ),
 
-                // header
-                widget.header != null ? Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  child: widget.header,
-                ) : Container(),
+                          // header
+                          widget.header != null ? Positioned(
+                            top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
+                            bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
+                            child: widget.header,
+                          ) : Container(),
 
-                // footer
-                widget.footer != null ? Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? null : 0.0,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? null : 0.0,
-                  child: widget.footer
-                ) : Container(),
+                          // footer
+                          widget.footer != null ? Positioned(
+                              top: widget.slideDirection == SlideDirection.UP ? null : 0.0,
+                              bottom: widget.slideDirection == SlideDirection.DOWN ? null : 0.0,
+                              child: widget.footer
+                          ) : Container(),
 
-                // collapsed panel
-                Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin.horizontal : 0) -
-                          (widget.padding != null ? widget.padding.horizontal : 0),
-                  child: Container(
-                    height: widget.minHeight,
-                    child: widget.collapsed == null ? Container() : FadeTransition(
-                      opacity: Tween(begin: 1.0, end: 0.0).animate(_ac),
+                          // collapsed panel
+                          Positioned(
+                            top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
+                            bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
+                            width:  MediaQuery.of(context).size.width -
+                                (widget.margin != null ? widget.margin.horizontal : 0) -
+                                (widget.padding != null ? widget.padding.horizontal : 0),
+                            child: Container(
+                              height: widget.minHeight,
+                              child: widget.collapsed == null ? Container() : FadeTransition(
+                                opacity: Tween(begin: 1.0, end: 0.0).animate(_ac),
 
-                      // if the panel is open ignore pointers (touch events) on the collapsed
-                      // child so that way touch events go through to whatever is underneath
-                      child: IgnorePointer(
-                        ignoring: _isPanelOpen,
-                        child: widget.collapsed
+                                // if the panel is open ignore pointers (touch events) on the collapsed
+                                // child so that way touch events go through to whatever is underneath
+                                child: IgnorePointer(
+                                    ignoring: _isPanelOpen,
+                                    child: widget.collapsed
+                                ),
+                              ),
+                            ),
+                          ),
+
+
+                        ],
                       ),
                     ),
                   ),
-                ),
 
-
-              ],
-            ),
-          ),
-        ),
-
-      ],
+                ],
+              );
+            }
+        )
     );
   }
 


### PR DESCRIPTION
Situation:

- Exception:
I have a `TabBar` inside my `SlidingUpPanel`'s `panelBuilder` with 2 tabs, each with their own `CustomScrollView`. 
I was using the `ScrollController` of the `panelBuilder` on each `CustomScrollView`, but I would always get this error repeatedly when switching tabs:
```
ScrollController attached to multiple scroll views.
```

This PR has fixed the exception and, as far as I can tell, maintains the original functionality. I tested the example app as well as my app and the scrolling behavior works like normal. Feel free to update this PR if a specific use case is broken because of this, testing will definitely be necessary.

- SafeArea:
I was having issues with elements on the screen expanding past the safe area and thus not being visible. Don't know how this will affect the example app, so it needs to be tested.