### PR TITLE
Add null safety

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,6 +3,8 @@ description: A simple example app for the sliding_up_panel package.
 
 version: 1.0.0
 
+publish_to: none
+
 environment:
   sdk: ">=2.1.0 <3.0.0"
 
@@ -25,5 +27,4 @@ dev_dependencies:
 
 
 flutter:
-
   uses-material-design: true

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -30,7 +30,7 @@ class SlidingUpPanel extends StatefulWidget {
   /// otherwise, [collapsed] will be displayed overtop
   /// of this Widget. If [panel] and [panelBuilder] are both non-null,
   /// [panel] will be used.
-  final Widget panel;
+  final Widget? panel;
 
   /// WARNING: This feature is still in beta and is subject to change without
   /// notice. Stability is not gauranteed. Provides a [ScrollController] and
@@ -38,28 +38,28 @@ class SlidingUpPanel extends StatefulWidget {
   /// the panel position with the scroll position. Useful for implementing an
   /// infinite scroll behavior. If [panel] and [panelBuilder] are both non-null,
   /// [panel] will be used.
-  final Widget Function(ScrollController sc) panelBuilder;
+  final Widget Function(ScrollController sc)? panelBuilder;
 
   /// The Widget displayed overtop the [panel] when collapsed.
   /// This fades out as the panel is opened.
-  final Widget collapsed;
+  final Widget? collapsed;
 
   /// The Widget that lies underneath the sliding panel.
   /// This Widget automatically sizes itself
   /// to fill the screen.
-  final Widget body;
+  final Widget? body;
 
   /// Optional persistent widget that floats above the [panel] and attaches
   /// to the top of the [panel]. Content at the top of the panel will be covered
   /// by this widget. Add padding to the bottom of the `panel` to
   /// avoid coverage.
-  final Widget header;
+  final Widget? header;
 
   /// Optional persistent widget that floats above the [panel] and
   /// attaches to the bottom of the [panel]. Content at the bottom of the panel
   /// will be covered by this widget. Add padding to the bottom of the `panel`
   /// to avoid coverage.
-  final Widget footer;
+  final Widget? footer;
 
   /// The height of the sliding panel when fully collapsed.
   final double minHeight;
@@ -72,13 +72,13 @@ class SlidingUpPanel extends StatefulWidget {
   /// and go directly to the open/close position. This value is represented as a
   /// percentage of the total animation distance ([maxHeight] - [minHeight]),
   /// so it must be between 0.0 and 1.0, exclusive.
-  final double snapPoint;
+  final double? snapPoint;
 
   /// A border to draw around the sliding panel sheet.
-  final Border border;
+  final Border? border;
 
   /// If non-null, the corners of the sliding panel sheet are rounded by this [BorderRadiusGeometry].
-  final BorderRadiusGeometry borderRadius;
+  final BorderRadiusGeometry? borderRadius;
 
   /// A list of shadows cast behind the sliding panel sheet.
   final List<BoxShadow> boxShadow;
@@ -87,10 +87,10 @@ class SlidingUpPanel extends StatefulWidget {
   final Color color;
 
   /// The amount to inset the children of the sliding panel sheet.
-  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry? padding;
 
   /// Empty space surrounding the sliding panel sheet.
-  final EdgeInsetsGeometry margin;
+  final EdgeInsetsGeometry? margin;
 
   /// Set to false to not to render the sheet the [panel] sits upon.
   /// This means that only the [body], [collapsed], and the [panel]
@@ -104,7 +104,7 @@ class SlidingUpPanel extends StatefulWidget {
   final bool panelSnapping;
 
   /// If non-null, this can be used to control the state of the panel.
-  final PanelController controller;
+  final PanelController? controller;
 
   /// If non-null, shows a darkening shadow over the [body] as the panel slides open.
   final bool backdropEnabled;
@@ -125,15 +125,15 @@ class SlidingUpPanel extends StatefulWidget {
   /// is called as the panel slides around with the
   /// current position of the panel. The position is a double
   /// between 0.0 and 1.0 where 0.0 is fully collapsed and 1.0 is fully open.
-  final void Function(double position) onPanelSlide;
+  final void Function(double position)? onPanelSlide;
 
   /// If non-null, this callback is called when the
   /// panel is fully opened
-  final VoidCallback onPanelOpened;
+  final VoidCallback? onPanelOpened;
 
   /// If non-null, this callback is called when the panel
   /// is fully collapsed.
-  final VoidCallback onPanelClosed;
+  final VoidCallback? onPanelClosed;
 
   /// If non-null and true, the SlidingUpPanel exhibits a
   /// parallax effect as the panel slides up. Essentially,
@@ -164,7 +164,7 @@ class SlidingUpPanel extends StatefulWidget {
   final PanelState defaultPanelState;
 
   SlidingUpPanel({
-    Key key,
+    Key? key,
     this.panel,
     this.panelBuilder,
     this.body,
@@ -201,9 +201,9 @@ class SlidingUpPanel extends StatefulWidget {
     this.header,
     this.footer
   }) : assert(panel != null || panelBuilder != null),
-       assert(0 <= backdropOpacity && backdropOpacity <= 1.0),
-       assert (snapPoint == null || 0 < snapPoint && snapPoint < 1.0),
-       super(key: key);
+      assert(0 <= backdropOpacity && backdropOpacity <= 1.0),
+      assert (snapPoint == null || 0 < snapPoint && snapPoint < 1.0),
+      super(key: key);
 
   @override
   _SlidingUpPanelState createState() => _SlidingUpPanelState();
@@ -211,9 +211,9 @@ class SlidingUpPanel extends StatefulWidget {
 
 class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProviderStateMixin{
 
-  AnimationController _ac;
+  late AnimationController _ac;
+  late ScrollController _sc;
 
-  ScrollController _sc;
   bool _scrollingEnabled = false;
   VelocityTracker _vt = new VelocityTracker();
 
@@ -228,11 +228,11 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
       duration: const Duration(milliseconds: 300),
       value: widget.defaultPanelState == PanelState.CLOSED ? 0.0 : 1.0 //set the default panel state (i.e. set initial value of _ac)
     )..addListener((){
-      if(widget.onPanelSlide != null) widget.onPanelSlide(_ac.value);
+      if(widget.onPanelSlide != null) widget.onPanelSlide!(_ac.value);
 
-      if(widget.onPanelOpened != null && _ac.value == 1.0) widget.onPanelOpened();
+      if(widget.onPanelOpened != null && _ac.value == 1.0) widget.onPanelOpened!();
 
-      if(widget.onPanelClosed != null && _ac.value == 0.0) widget.onPanelClosed();
+      if(widget.onPanelClosed != null && _ac.value == 0.0) widget.onPanelClosed!();
     });
 
     // prevent the panel content from being scrolled only if the widget is
@@ -259,7 +259,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
           builder: (context, child){
             return Positioned(
               top: widget.parallaxEnabled ? _getParallax() : 0.0,
-              child: child,
+              child: child ?? SizedBox(),
             );
           },
           child: Container(
@@ -321,13 +321,13 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
                   top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
                   bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
                   width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin.horizontal : 0) -
-                          (widget.padding != null ? widget.padding.horizontal : 0),
+                          (widget.margin != null ? widget.margin!.horizontal : 0) -
+                          (widget.padding != null ? widget.padding!.horizontal : 0),
                   child: Container(
                     height: widget.maxHeight,
                     child: widget.panel != null
                             ? widget.panel
-                            : widget.panelBuilder(_sc),
+                            : widget.panelBuilder!(_sc),
                   )
                 ),
 
@@ -335,14 +335,14 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
                 widget.header != null ? Positioned(
                   top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
                   bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  child: widget.header,
+                  child: widget.header ?? SizedBox(),
                 ) : Container(),
 
                 // footer
                 widget.footer != null ? Positioned(
                   top: widget.slideDirection == SlideDirection.UP ? null : 0.0,
                   bottom: widget.slideDirection == SlideDirection.DOWN ? null : 0.0,
-                  child: widget.footer
+                  child: widget.footer ?? SizedBox()
                 ) : Container(),
 
                 // collapsed panel
@@ -350,8 +350,8 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
                   top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
                   bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
                   width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin.horizontal : 0) -
-                          (widget.padding != null ? widget.padding.horizontal : 0),
+                          (widget.margin != null ? widget.margin!.horizontal : 0) -
+                          (widget.padding != null ? widget.padding!.horizontal : 0),
                   child: Container(
                     height: widget.minHeight,
                     child: widget.collapsed == null ? Container() : FadeTransition(
@@ -394,7 +394,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   // and a listener if panelBuilder is used.
   // this is because the listener is designed only for use with linking the scrolling of
   // panels and using it for panels that don't want to linked scrolling yields odd results
-  Widget _gestureHandler({Widget child}){
+  Widget _gestureHandler({required Widget child}){
     if (!widget.isDraggable) return child;
 
     if (widget.panel != null){
@@ -475,7 +475,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
         if(v.pixelsPerSecond.dy.abs() >= kSnap*minFlingVelocity || minDistance == d2Snap)
           _ac.fling(velocity: visualVelocity);
         else
-          _flingPanelToPosition(widget.snapPoint, visualVelocity);
+          _flingPanelToPosition(widget.snapPoint!, visualVelocity);
 
       // no snap point exists
       }else if(widget.panelSnapping){
@@ -499,7 +499,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
       if(minDistance == d2Close){
         _close();
       }else if(minDistance == d2Snap){
-        _flingPanelToPosition(widget.snapPoint, visualVelocity);
+        _flingPanelToPosition(widget.snapPoint!, visualVelocity);
       }else{
         _open();
       }
@@ -556,16 +556,16 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
   //animate the panel position to value - must
   //be between 0.0 and 1.0
-  Future<void> _animatePanelToPosition(double value, {Duration duration, Curve curve = Curves.linear}){
+  Future<void> _animatePanelToPosition(double value, {Duration? duration, Curve curve = Curves.linear}){
     assert(0.0 <= value && value <= 1.0);
     return _ac.animateTo(value, duration: duration, curve: curve);
   }
 
   //animate the panel position to the snap point
   //REQUIRES that widget.snapPoint != null
-  Future<void> _animatePanelToSnapPoint({Duration duration, Curve curve = Curves.linear}){
+  Future<void> _animatePanelToSnapPoint({Duration? duration, Curve curve = Curves.linear}){
     assert(widget.snapPoint != null);
-    return _ac.animateTo(widget.snapPoint, duration: duration, curve: curve);
+    return _ac.animateTo(widget.snapPoint!, duration: duration, curve: curve);
   }
 
   //set the panel position to value - must
@@ -606,7 +606,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
 
 class PanelController{
-  _SlidingUpPanelState _panelState;
+  _SlidingUpPanelState? _panelState;
 
   void _addState(_SlidingUpPanelState panelState){
     this._panelState = panelState;
@@ -620,27 +620,27 @@ class PanelController{
   /// Closes the sliding panel to its collapsed state (i.e. to the  minHeight)
   Future<void> close(){
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._close();
+    return _panelState!._close();
   }
 
   /// Opens the sliding panel fully
   /// (i.e. to the maxHeight)
   Future<void> open(){
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._open();
+    return _panelState!._open();
   }
 
   /// Hides the sliding panel (i.e. is invisible)
   Future<void> hide(){
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._hide();
+    return _panelState!._hide();
   }
 
   /// Shows the sliding panel in its collapsed state
   /// (i.e. "un-hide" the sliding panel)
   Future<void> show(){
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._show();
+    return _panelState!._show();
   }
 
   /// Animates the panel position to the value.
@@ -648,20 +648,20 @@ class PanelController{
   /// where 0.0 is fully collapsed and 1.0 is completely open.
   /// (optional) duration specifies the time for the animation to complete
   /// (optional) curve specifies the easing behavior of the animation.
-  Future<void> animatePanelToPosition(double value, {Duration duration, Curve curve = Curves.linear}){
+  Future<void> animatePanelToPosition(double value, {Duration? duration, Curve curve = Curves.linear}){
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     assert(0.0 <= value && value <= 1.0);
-    return _panelState._animatePanelToPosition(value, duration: duration, curve: curve);
+    return _panelState!._animatePanelToPosition(value, duration: duration, curve: curve);
   }
 
   /// Animates the panel position to the snap point
   /// Requires that the SlidingUpPanel snapPoint property is not null
   /// (optional) duration specifies the time for the animation to complete
   /// (optional) curve specifies the easing behavior of the animation.
-  Future<void> animatePanelToSnapPoint({Duration duration, Curve curve = Curves.linear}){
+  Future<void> animatePanelToSnapPoint({Duration? duration, Curve curve = Curves.linear}){
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    assert(_panelState.widget.snapPoint != null, "SlidingUpPanel snapPoint property must not be null");
-    return _panelState._animatePanelToSnapPoint(duration: duration, curve: curve);
+    assert(_panelState!.widget.snapPoint != null, "SlidingUpPanel snapPoint property must not be null");
+    return _panelState!._animatePanelToSnapPoint(duration: duration, curve: curve);
   }
 
   /// Sets the panel position (without animation).
@@ -670,7 +670,7 @@ class PanelController{
   set panelPosition(double value){
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     assert(0.0 <= value && value <= 1.0);
-    _panelState._panelPosition = value;
+    _panelState!._panelPosition = value;
   }
 
   /// Gets the current panel position.
@@ -681,35 +681,35 @@ class PanelController{
   /// 1.0 is full open.
   double get panelPosition{
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._panelPosition;
+    return _panelState!._panelPosition;
   }
 
   /// Returns whether or not the panel is
   /// currently animating.
   bool get isPanelAnimating{
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._isPanelAnimating;
+    return _panelState!._isPanelAnimating;
   }
 
   /// Returns whether or not the
   /// panel is open.
   bool get isPanelOpen{
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._isPanelOpen;
+    return _panelState!._isPanelOpen;
   }
 
   /// Returns whether or not the
   /// panel is closed.
   bool get isPanelClosed{
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._isPanelClosed;
+    return _panelState!._isPanelClosed;
   }
 
   /// Returns whether or not the
   /// panel is shown/hidden.
   bool get isPanelShown{
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    return _panelState._isPanelShown;
+    return _panelState!._isPanelShown;
   }
 
 }

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -211,7 +211,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
   late ScrollController _sc;
 
   bool _scrollingEnabled = false;
-  VelocityTracker _vt = new VelocityTracker();
+  VelocityTracker _vt = new VelocityTracker.withKind(PointerDeviceKind.touch);
 
   bool _isPanelVisible = true;
 

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -12,18 +12,14 @@ import 'dart:math';
 
 import 'package:flutter/physics.dart';
 
-enum SlideDirection{
+enum SlideDirection {
   UP,
   DOWN,
 }
 
-enum PanelState{
-  OPEN,
-  CLOSED
-}
+enum PanelState { OPEN, CLOSED }
 
 class SlidingUpPanel extends StatefulWidget {
-
   /// The Widget that slides into view. When the
   /// panel is collapsed and if [collapsed] is null,
   /// then top portion of this Widget will be displayed;
@@ -163,54 +159,54 @@ class SlidingUpPanel extends StatefulWidget {
   /// by default the Panel is open and must be swiped closed by the user.
   final PanelState defaultPanelState;
 
-  SlidingUpPanel({
-    Key? key,
-    this.panel,
-    this.panelBuilder,
-    this.body,
-    this.collapsed,
-    this.minHeight = 100.0,
-    this.maxHeight = 500.0,
-    this.snapPoint,
-    this.border,
-    this.borderRadius,
-    this.boxShadow = const <BoxShadow>[
-      BoxShadow(
-        blurRadius: 8.0,
-        color: Color.fromRGBO(0, 0, 0, 0.25),
-      )
-    ],
-    this.color = Colors.white,
-    this.padding,
-    this.margin,
-    this.renderPanelSheet = true,
-    this.panelSnapping = true,
-    this.controller,
-    this.backdropEnabled = false,
-    this.backdropColor = Colors.black,
-    this.backdropOpacity = 0.5,
-    this.backdropTapClosesPanel = true,
-    this.onPanelSlide,
-    this.onPanelOpened,
-    this.onPanelClosed,
-    this.parallaxEnabled = false,
-    this.parallaxOffset = 0.1,
-    this.isDraggable = true,
-    this.slideDirection = SlideDirection.UP,
-    this.defaultPanelState = PanelState.CLOSED,
-    this.header,
-    this.footer
-  }) : assert(panel != null || panelBuilder != null),
-      assert(0 <= backdropOpacity && backdropOpacity <= 1.0),
-      assert (snapPoint == null || 0 < snapPoint && snapPoint < 1.0),
-      super(key: key);
+  SlidingUpPanel(
+      {Key? key,
+      this.panel,
+      this.panelBuilder,
+      this.body,
+      this.collapsed,
+      this.minHeight = 100.0,
+      this.maxHeight = 500.0,
+      this.snapPoint,
+      this.border,
+      this.borderRadius,
+      this.boxShadow = const <BoxShadow>[
+        BoxShadow(
+          blurRadius: 8.0,
+          color: Color.fromRGBO(0, 0, 0, 0.25),
+        )
+      ],
+      this.color = Colors.white,
+      this.padding,
+      this.margin,
+      this.renderPanelSheet = true,
+      this.panelSnapping = true,
+      this.controller,
+      this.backdropEnabled = false,
+      this.backdropColor = Colors.black,
+      this.backdropOpacity = 0.5,
+      this.backdropTapClosesPanel = true,
+      this.onPanelSlide,
+      this.onPanelOpened,
+      this.onPanelClosed,
+      this.parallaxEnabled = false,
+      this.parallaxOffset = 0.1,
+      this.isDraggable = true,
+      this.slideDirection = SlideDirection.UP,
+      this.defaultPanelState = PanelState.CLOSED,
+      this.header,
+      this.footer})
+      : assert(panel != null || panelBuilder != null),
+        assert(0 <= backdropOpacity && backdropOpacity <= 1.0),
+        assert(snapPoint == null || 0 < snapPoint && snapPoint < 1.0),
+        super(key: key);
 
   @override
   _SlidingUpPanelState createState() => _SlidingUpPanelState();
 }
 
-class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProviderStateMixin{
-
+class _SlidingUpPanelState extends State<SlidingUpPanel>
+    with SingleTickerProviderStateMixin {
   late AnimationController _ac;
   late ScrollController _sc;
 
@@ -220,27 +216,31 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   bool _isPanelVisible = true;
 
   @override
-  void initState(){
+  void initState() {
     super.initState();
 
     _ac = new AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 300),
-      value: widget.defaultPanelState == PanelState.CLOSED ? 0.0 : 1.0 //set the default panel state (i.e. set initial value of _ac)
-    )..addListener((){
-      if(widget.onPanelSlide != null) widget.onPanelSlide!(_ac.value);
+        vsync: this,
+        duration: const Duration(milliseconds: 300),
+        value: widget.defaultPanelState == PanelState.CLOSED
+            ? 0.0
+            : 1.0 //set the default panel state (i.e. set initial value of _ac)
+        )
+      ..addListener(() {
+        if (widget.onPanelSlide != null) widget.onPanelSlide!(_ac.value);
 
-      if(widget.onPanelOpened != null && _ac.value == 1.0) widget.onPanelOpened!();
+        if (widget.onPanelOpened != null && _ac.value == 1.0)
+          widget.onPanelOpened!();
 
-      if(widget.onPanelClosed != null && _ac.value == 0.0) widget.onPanelClosed!();
-    });
+        if (widget.onPanelClosed != null && _ac.value == 0.0)
+          widget.onPanelClosed!();
+      });
 
     // prevent the panel content from being scrolled only if the widget is
     // draggable and panel scrolling is enabled
     _sc = new ScrollController();
-    _sc.addListener((){
-      if(widget.isDraggable && !_scrollingEnabled)
-        _sc.jumpTo(0);
+    _sc.addListener(() {
+      if (widget.isDraggable && !_scrollingEnabled) _sc.jumpTo(0);
     });
 
     widget.controller?._addState(this);
@@ -249,166 +249,215 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   @override
   Widget build(BuildContext context) {
     return Stack(
-      alignment: widget.slideDirection == SlideDirection.UP ? Alignment.bottomCenter : Alignment.topCenter,
+      alignment: widget.slideDirection == SlideDirection.UP
+          ? Alignment.bottomCenter
+          : Alignment.topCenter,
       children: <Widget>[
-
-
         //make the back widget take up the entire back side
-        widget.body != null ? AnimatedBuilder(
-          animation: _ac,
-          builder: (context, child){
-            return Positioned(
-              top: widget.parallaxEnabled ? _getParallax() : 0.0,
-              child: child ?? SizedBox(),
-            );
-          },
-          child: Container(
-            height: MediaQuery.of(context).size.height,
-            width: MediaQuery.of(context).size.width,
-            child: widget.body,
-          ),
-        ) : Container(),
-
+        widget.body != null
+            ? AnimatedBuilder(
+                animation: _ac,
+                builder: (context, child) {
+                  return Positioned(
+                    top: widget.parallaxEnabled ? _getParallax() : 0.0,
+                    child: child ?? SizedBox(),
+                  );
+                },
+                child: Container(
+                  height: MediaQuery.of(context).size.height,
+                  width: MediaQuery.of(context).size.width,
+                  child: widget.body,
+                ),
+              )
+            : Container(),
 
         //the backdrop to overlay on the body
-        !widget.backdropEnabled ? Container() : GestureDetector(
-          onVerticalDragEnd: widget.backdropTapClosesPanel ? (DragEndDetails dets){
-            // only trigger a close if the drag is towards panel close position
-            if((widget.slideDirection == SlideDirection.UP ? 1 : -1) * dets.velocity.pixelsPerSecond.dy > 0)
-              _close();
-          } : null,
-          onTap: widget.backdropTapClosesPanel ? () => _close() : null,
-          child: AnimatedBuilder(
-            animation: _ac,
-            builder: (context, _) {
-              return Container(
-                height: MediaQuery.of(context).size.height,
-                width: MediaQuery.of(context).size.width,
+        !widget.backdropEnabled
+            ? Container()
+            : GestureDetector(
+                onVerticalDragEnd: widget.backdropTapClosesPanel
+                    ? (DragEndDetails dets) {
+                        // only trigger a close if the drag is towards panel close position
+                        if ((widget.slideDirection == SlideDirection.UP
+                                    ? 1
+                                    : -1) *
+                                dets.velocity.pixelsPerSecond.dy >
+                            0) _close();
+                      }
+                    : null,
+                onTap: widget.backdropTapClosesPanel ? () => _close() : null,
+                child: AnimatedBuilder(
+                    animation: _ac,
+                    builder: (context, _) {
+                      return Container(
+                        height: MediaQuery.of(context).size.height,
+                        width: MediaQuery.of(context).size.width,
 
-                //set color to null so that touch events pass through
-                //to the body when the panel is closed, otherwise,
-                //if a color exists, then touch events won't go through
-                color: _ac.value == 0.0 ? null : widget.backdropColor.withOpacity(widget.backdropOpacity * _ac.value),
-              );
-            }
-          ),
-        ),
-
+                        //set color to null so that touch events pass through
+                        //to the body when the panel is closed, otherwise,
+                        //if a color exists, then touch events won't go through
+                        color: _ac.value == 0.0
+                            ? null
+                            : widget.backdropColor.withOpacity(
+                                widget.backdropOpacity * _ac.value),
+                      );
+                    }),
+              ),
 
         //the actual sliding part
-        !_isPanelVisible ? Container() : _gestureHandler(
-          child: AnimatedBuilder(
-            animation: _ac,
-            builder: (context, child) {
-              return Container(
-                height: _ac.value * (widget.maxHeight - widget.minHeight) + widget.minHeight,
-                margin: widget.margin,
-                padding: widget.padding,
-                decoration: widget.renderPanelSheet ? BoxDecoration(
-                  border: widget.border,
-                  borderRadius: widget.borderRadius,
-                  boxShadow: widget.boxShadow,
-                  color: widget.color,
-                ) : null,
-                child: child,
-              );
-            },
-            child: Stack(
-              children: <Widget>[
+        !_isPanelVisible
+            ? Container()
+            : _gestureHandler(
+                child: AnimatedBuilder(
+                  animation: _ac,
+                  builder: (context, child) {
+                    return Container(
+                      height:
+                          _ac.value * (widget.maxHeight - widget.minHeight) +
+                              widget.minHeight,
+                      margin: widget.margin,
+                      padding: widget.padding,
+                      decoration: widget.renderPanelSheet
+                          ? BoxDecoration(
+                              border: widget.border,
+                              borderRadius: widget.borderRadius,
+                              boxShadow: widget.boxShadow,
+                              color: widget.color,
+                            )
+                          : null,
+                      child: child,
+                    );
+                  },
+                  child: Stack(
+                    children: <Widget>[
+                      //open panel
+                      Positioned(
+                          top: widget.slideDirection == SlideDirection.UP
+                              ? 0.0
+                              : null,
+                          bottom: widget.slideDirection == SlideDirection.DOWN
+                              ? 0.0
+                              : null,
+                          width: MediaQuery.of(context).size.width -
+                              (widget.margin != null
+                                  ? widget.margin!.horizontal
+                                  : 0) -
+                              (widget.padding != null
+                                  ? widget.padding!.horizontal
+                                  : 0),
+                          child: Container(
+                            height: widget.maxHeight,
+                            child: widget.panel != null
+                                ? widget.panel
+                                : widget.panelBuilder!(_sc),
+                          )),
 
-                //open panel
-                Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin!.horizontal : 0) -
-                          (widget.padding != null ? widget.padding!.horizontal : 0),
-                  child: Container(
-                    height: widget.maxHeight,
-                    child: widget.panel != null
-                            ? widget.panel
-                            : widget.panelBuilder!(_sc),
-                  )
-                ),
+                      // header
+                      widget.header != null
+                          ? Positioned(
+                              top: widget.slideDirection == SlideDirection.UP
+                                  ? 0.0
+                                  : null,
+                              bottom:
+                                  widget.slideDirection == SlideDirection.DOWN
+                                      ? 0.0
+                                      : null,
+                              child: widget.header ?? SizedBox(),
+                            )
+                          : Container(),
 
-                // header
-                widget.header != null ? Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  child: widget.header ?? SizedBox(),
-                ) : Container(),
+                      // footer
+                      widget.footer != null
+                          ? Positioned(
+                              top: widget.slideDirection == SlideDirection.UP
+                                  ? null
+                                  : 0.0,
+                              bottom:
+                                  widget.slideDirection == SlideDirection.DOWN
+                                      ? null
+                                      : 0.0,
+                              child: widget.footer ?? SizedBox())
+                          : Container(),
 
-                // footer
-                widget.footer != null ? Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? null : 0.0,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? null : 0.0,
-                  child: widget.footer ?? SizedBox()
-                ) : Container(),
+                      // collapsed panel
+                      Positioned(
+                        top: widget.slideDirection == SlideDirection.UP
+                            ? 0.0
+                            : null,
+                        bottom: widget.slideDirection == SlideDirection.DOWN
+                            ? 0.0
+                            : null,
+                        width: MediaQuery.of(context).size.width -
+                            (widget.margin != null
+                                ? widget.margin!.horizontal
+                                : 0) -
+                            (widget.padding != null
+                                ? widget.padding!.horizontal
+                                : 0),
+                        child: Container(
+                          height: widget.minHeight,
+                          child: widget.collapsed == null
+                              ? Container()
+                              : FadeTransition(
+                                  opacity:
+                                      Tween(begin: 1.0, end: 0.0).animate(_ac),
 
-                // collapsed panel
-                Positioned(
-                  top: widget.slideDirection == SlideDirection.UP ? 0.0 : null,
-                  bottom: widget.slideDirection == SlideDirection.DOWN ? 0.0 : null,
-                  width:  MediaQuery.of(context).size.width -
-                          (widget.margin != null ? widget.margin!.horizontal : 0) -
-                          (widget.padding != null ? widget.padding!.horizontal : 0),
-                  child: Container(
-                    height: widget.minHeight,
-                    child: widget.collapsed == null ? Container() : FadeTransition(
-                      opacity: Tween(begin: 1.0, end: 0.0).animate(_ac),
-
-                      // if the panel is open ignore pointers (touch events) on the collapsed
-                      // child so that way touch events go through to whatever is underneath
-                      child: IgnorePointer(
-                        ignoring: _isPanelOpen,
-                        child: widget.collapsed
+                                  // if the panel is open ignore pointers (touch events) on the collapsed
+                                  // child so that way touch events go through to whatever is underneath
+                                  child: IgnorePointer(
+                                      ignoring: _isPanelOpen,
+                                      child: widget.collapsed),
+                                ),
+                        ),
                       ),
-                    ),
+                    ],
                   ),
                 ),
-
-
-              ],
-            ),
-          ),
-        ),
-
+              ),
       ],
     );
   }
 
   @override
-  void dispose(){
+  void dispose() {
     _ac.dispose();
     super.dispose();
   }
 
-  double _getParallax(){
-    if(widget.slideDirection == SlideDirection.UP)
-      return -_ac.value * (widget.maxHeight - widget.minHeight) * widget.parallaxOffset;
+  double _getParallax() {
+    if (widget.slideDirection == SlideDirection.UP)
+      return -_ac.value *
+          (widget.maxHeight - widget.minHeight) *
+          widget.parallaxOffset;
     else
-      return _ac.value * (widget.maxHeight - widget.minHeight) * widget.parallaxOffset;
+      return _ac.value *
+          (widget.maxHeight - widget.minHeight) *
+          widget.parallaxOffset;
   }
 
   // returns a gesture detector if panel is used
   // and a listener if panelBuilder is used.
   // this is because the listener is designed only for use with linking the scrolling of
   // panels and using it for panels that don't want to linked scrolling yields odd results
-  Widget _gestureHandler({required Widget child}){
+  Widget _gestureHandler({required Widget child}) {
     if (!widget.isDraggable) return child;
 
-    if (widget.panel != null){
+    if (widget.panel != null) {
       return GestureDetector(
-        onVerticalDragUpdate: (DragUpdateDetails dets) => _onGestureSlide(dets.delta.dy),
-        onVerticalDragEnd: (DragEndDetails dets) => _onGestureEnd(dets.velocity),
+        onVerticalDragUpdate: (DragUpdateDetails dets) =>
+            _onGestureSlide(dets.delta.dy),
+        onVerticalDragEnd: (DragEndDetails dets) =>
+            _onGestureEnd(dets.velocity),
         child: child,
       );
     }
 
     return Listener(
-      onPointerDown: (PointerDownEvent p) => _vt.addPosition(p.timeStamp, p.position),
-      onPointerMove: (PointerMoveEvent p){
-        _vt.addPosition(p.timeStamp, p.position); // add current position for velocity tracking
+      onPointerDown: (PointerDownEvent p) =>
+          _vt.addPosition(p.timeStamp, p.position),
+      onPointerMove: (PointerMoveEvent p) {
+        _vt.addPosition(p.timeStamp,
+            p.position); // add current position for velocity tracking
         _onGestureSlide(p.delta.dy);
       },
       onPointerUp: (PointerUpEvent p) => _onGestureEnd(_vt.getVelocity()),
@@ -417,11 +466,10 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   }
 
   // handles the sliding gesture
-  void _onGestureSlide(double dy){
-
+  void _onGestureSlide(double dy) {
     // only slide the panel if scrolling is not enabled
-    if(!_scrollingEnabled){
-      if(widget.slideDirection == SlideDirection.UP)
+    if (!_scrollingEnabled) {
+      if (widget.slideDirection == SlideDirection.UP)
         _ac.value -= dy / (widget.maxHeight - widget.minHeight);
       else
         _ac.value += dy / (widget.maxHeight - widget.minHeight);
@@ -430,11 +478,11 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
     // if the panel is open and the user hasn't scrolled, we need to determine
     // whether to enable scrolling if the user swipes up, or disable closing and
     // begin to close the panel if the user swipes down
-    if(_isPanelOpen && _sc.hasClients && _sc.offset <= 0){
+    if (_isPanelOpen && _sc.hasClients && _sc.offset <= 0) {
       setState(() {
-        if(dy < 0){
+        if (dy < 0) {
           _scrollingEnabled = true;
-        }else{
+        } else {
           _scrollingEnabled = false;
         }
       });
@@ -442,47 +490,48 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   }
 
   // handles when user stops sliding
-  void _onGestureEnd(Velocity v){
+  void _onGestureEnd(Velocity v) {
     double minFlingVelocity = 365.0;
     double kSnap = 8;
 
     //let the current animation finish before starting a new one
-    if(_ac.isAnimating) return;
+    if (_ac.isAnimating) return;
 
     // if scrolling is allowed and the panel is open, we don't want to close
     // the panel if they swipe up on the scrollable
-    if(_isPanelOpen && _scrollingEnabled) return;
+    if (_isPanelOpen && _scrollingEnabled) return;
 
     //check if the velocity is sufficient to constitute fling to end
-    double visualVelocity = -v.pixelsPerSecond.dy / (widget.maxHeight - widget.minHeight);
+    double visualVelocity =
+        -v.pixelsPerSecond.dy / (widget.maxHeight - widget.minHeight);
 
     // reverse visual velocity to account for slide direction
-    if(widget.slideDirection == SlideDirection.DOWN)
+    if (widget.slideDirection == SlideDirection.DOWN)
       visualVelocity = -visualVelocity;
-
 
     // get minimum distances to figure out where the panel is at
     double d2Close = _ac.value;
     double d2Open = 1 - _ac.value;
-    double d2Snap = ((widget.snapPoint ?? 3) -_ac.value).abs(); // large value if null results in not every being the min
+    double d2Snap = ((widget.snapPoint ?? 3) - _ac.value)
+        .abs(); // large value if null results in not every being the min
     double minDistance = min(d2Close, min(d2Snap, d2Open));
 
     // check if velocity is sufficient for a fling
-    if(v.pixelsPerSecond.dy.abs() >= minFlingVelocity){
-
+    if (v.pixelsPerSecond.dy.abs() >= minFlingVelocity) {
       // snapPoint exists
-      if(widget.panelSnapping && widget.snapPoint != null){
-        if(v.pixelsPerSecond.dy.abs() >= kSnap*minFlingVelocity || minDistance == d2Snap)
+      if (widget.panelSnapping && widget.snapPoint != null) {
+        if (v.pixelsPerSecond.dy.abs() >= kSnap * minFlingVelocity ||
+            minDistance == d2Snap)
           _ac.fling(velocity: visualVelocity);
         else
           _flingPanelToPosition(widget.snapPoint!, visualVelocity);
 
-      // no snap point exists
-      }else if(widget.panelSnapping){
+        // no snap point exists
+      } else if (widget.panelSnapping) {
         _ac.fling(velocity: visualVelocity);
 
-      // panel snapping disabled
-      }else{
+        // panel snapping disabled
+      } else {
         _ac.animateTo(
           _ac.value + visualVelocity * 0.16,
           duration: Duration(milliseconds: 410),
@@ -495,29 +544,26 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
     // check if the controller is already halfway there
     if (widget.panelSnapping) {
-
-      if(minDistance == d2Close){
+      if (minDistance == d2Close) {
         _close();
-      }else if(minDistance == d2Snap){
+      } else if (minDistance == d2Snap) {
         _flingPanelToPosition(widget.snapPoint!, visualVelocity);
-      }else{
+      } else {
         _open();
       }
     }
-
   }
 
-  void _flingPanelToPosition(double targetPos, double velocity){
+  void _flingPanelToPosition(double targetPos, double velocity) {
     final Simulation simulation = SpringSimulation(
-      SpringDescription.withDampingRatio(
-        mass: 1.0,
-        stiffness: 500.0,
-        ratio: 1.0,
-      ),
-      _ac.value,
-      targetPos,
-      velocity
-    );
+        SpringDescription.withDampingRatio(
+          mass: 1.0,
+          stiffness: 500.0,
+          ratio: 1.0,
+        ),
+        _ac.value,
+        targetPos,
+        velocity);
 
     _ac.animateWith(simulation);
   }
@@ -527,18 +573,18 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   //---------------------------------
 
   //close the panel
-  Future<void> _close(){
+  Future<void> _close() {
     return _ac.fling(velocity: -1.0);
   }
 
   //open the panel
-  Future<void> _open(){
+  Future<void> _open() {
     return _ac.fling(velocity: 1.0);
   }
 
   //hide the panel (completely offscreen)
-  Future<void> _hide(){
-    return _ac.fling(velocity: -1.0).then((x){
+  Future<void> _hide() {
+    return _ac.fling(velocity: -1.0).then((x) {
       setState(() {
         _isPanelVisible = false;
       });
@@ -546,8 +592,8 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   }
 
   //show the panel (in collapsed mode)
-  Future<void> _show(){
-    return _ac.fling(velocity: -1.0).then((x){
+  Future<void> _show() {
+    return _ac.fling(velocity: -1.0).then((x) {
       setState(() {
         _isPanelVisible = true;
       });
@@ -556,21 +602,23 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
 
   //animate the panel position to value - must
   //be between 0.0 and 1.0
-  Future<void> _animatePanelToPosition(double value, {Duration? duration, Curve curve = Curves.linear}){
+  Future<void> _animatePanelToPosition(double value,
+      {Duration? duration, Curve curve = Curves.linear}) {
     assert(0.0 <= value && value <= 1.0);
     return _ac.animateTo(value, duration: duration, curve: curve);
   }
 
   //animate the panel position to the snap point
   //REQUIRES that widget.snapPoint != null
-  Future<void> _animatePanelToSnapPoint({Duration? duration, Curve curve = Curves.linear}){
+  Future<void> _animatePanelToSnapPoint(
+      {Duration? duration, Curve curve = Curves.linear}) {
     assert(widget.snapPoint != null);
     return _ac.animateTo(widget.snapPoint!, duration: duration, curve: curve);
   }
 
   //set the panel position to value - must
   //be between 0.0 and 1.0
-  set _panelPosition(double value){
+  set _panelPosition(double value) {
     assert(0.0 <= value && value <= 1.0);
     _ac.value = value;
   }
@@ -595,20 +643,12 @@ class _SlidingUpPanelState extends State<SlidingUpPanel> with SingleTickerProvid
   //returns whether or not the
   //panel is shown/hidden
   bool get _isPanelShown => _isPanelVisible;
-
 }
 
-
-
-
-
-
-
-
-class PanelController{
+class PanelController {
   _SlidingUpPanelState? _panelState;
 
-  void _addState(_SlidingUpPanelState panelState){
+  void _addState(_SlidingUpPanelState panelState) {
     this._panelState = panelState;
   }
 
@@ -618,27 +658,27 @@ class PanelController{
   bool get isAttached => _panelState != null;
 
   /// Closes the sliding panel to its collapsed state (i.e. to the  minHeight)
-  Future<void> close(){
+  Future<void> close() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._close();
   }
 
   /// Opens the sliding panel fully
   /// (i.e. to the maxHeight)
-  Future<void> open(){
+  Future<void> open() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._open();
   }
 
   /// Hides the sliding panel (i.e. is invisible)
-  Future<void> hide(){
+  Future<void> hide() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._hide();
   }
 
   /// Shows the sliding panel in its collapsed state
   /// (i.e. "un-hide" the sliding panel)
-  Future<void> show(){
+  Future<void> show() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._show();
   }
@@ -648,26 +688,31 @@ class PanelController{
   /// where 0.0 is fully collapsed and 1.0 is completely open.
   /// (optional) duration specifies the time for the animation to complete
   /// (optional) curve specifies the easing behavior of the animation.
-  Future<void> animatePanelToPosition(double value, {Duration? duration, Curve curve = Curves.linear}){
+  Future<void> animatePanelToPosition(double value,
+      {Duration? duration, Curve curve = Curves.linear}) {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     assert(0.0 <= value && value <= 1.0);
-    return _panelState!._animatePanelToPosition(value, duration: duration, curve: curve);
+    return _panelState!
+        ._animatePanelToPosition(value, duration: duration, curve: curve);
   }
 
   /// Animates the panel position to the snap point
   /// Requires that the SlidingUpPanel snapPoint property is not null
   /// (optional) duration specifies the time for the animation to complete
   /// (optional) curve specifies the easing behavior of the animation.
-  Future<void> animatePanelToSnapPoint({Duration? duration, Curve curve = Curves.linear}){
+  Future<void> animatePanelToSnapPoint(
+      {Duration? duration, Curve curve = Curves.linear}) {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
-    assert(_panelState!.widget.snapPoint != null, "SlidingUpPanel snapPoint property must not be null");
-    return _panelState!._animatePanelToSnapPoint(duration: duration, curve: curve);
+    assert(_panelState!.widget.snapPoint != null,
+        "SlidingUpPanel snapPoint property must not be null");
+    return _panelState!
+        ._animatePanelToSnapPoint(duration: duration, curve: curve);
   }
 
   /// Sets the panel position (without animation).
   /// The value must between 0.0 and 1.0
   /// where 0.0 is fully collapsed and 1.0 is completely open.
-  set panelPosition(double value){
+  set panelPosition(double value) {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     assert(0.0 <= value && value <= 1.0);
     _panelState!._panelPosition = value;
@@ -679,37 +724,36 @@ class PanelController{
   /// as a decimal between 0.0 and 1.0
   /// where 0.0 is fully collapsed and
   /// 1.0 is full open.
-  double get panelPosition{
+  double get panelPosition {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._panelPosition;
   }
 
   /// Returns whether or not the panel is
   /// currently animating.
-  bool get isPanelAnimating{
+  bool get isPanelAnimating {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._isPanelAnimating;
   }
 
   /// Returns whether or not the
   /// panel is open.
-  bool get isPanelOpen{
+  bool get isPanelOpen {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._isPanelOpen;
   }
 
   /// Returns whether or not the
   /// panel is closed.
-  bool get isPanelClosed{
+  bool get isPanelClosed {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._isPanelClosed;
   }
 
   /// Returns whether or not the
   /// panel is shown/hidden.
-  bool get isPanelShown{
+  bool get isPanelShown {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
     return _panelState!._isPanelShown;
   }
-
 }

--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -77,7 +77,7 @@ class SlidingUpPanel extends StatefulWidget {
   final BorderRadiusGeometry? borderRadius;
 
   /// A list of shadows cast behind the sliding panel sheet.
-  final List<BoxShadow> boxShadow;
+  final List<BoxShadow>? boxShadow;
 
   /// The color to fill the background of the sliding panel sheet.
   final Color color;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,5 +13,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.2
 homepage: https://github.com/akshathjain/sliding_up_panel
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This adds null safety to the sliding up panel.

While it functions perfectly fine for me with an application I am working on, I have not tested everything and every case. That said, I highly encourage further testing to see if it functions exactly as it did before the changes (in terms of functionality and user experience).

This does not add null safety to the example as some of its dependencies do not have null safety prepared versions available.

Regards #223.