### PR TITLE
When closing the panel from (eg.) a tap on the backdrop, reset and turn off integrated panel scrolling

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -574,6 +574,12 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
 
   //close the panel
   Future<void> _close() {
+    if (_scrollingEnabled) {
+      setState(() {
+        _sc.jumpTo(0);
+        _scrollingEnabled = false;
+      });
+    }
     return _ac.fling(velocity: -1.0);
   }
 


### PR DESCRIPTION
Otherwise it's impossible to drag the panel up again by the header, because although we receive the drag events on the listener, `_scrollingEnabled` is set to true, so the slide handler ignores the event.