### PR TITLE
Enable scrolling when opening pannel programmatically

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -667,6 +667,8 @@ class PanelController {
   /// (i.e. to the maxHeight)
   Future<void> open() {
     assert(isAttached, "PanelController must be attached to a SlidingUpPanel");
+    // Enable scrolling when panel is opened programmatically
+    _panelState!._scrollingEnabled = true;
     return _panelState!._open();
   }
 


### PR DESCRIPTION
Pull Request to fix the wrong behavior described in Issue #239 

For more information refer to my comment on this Issue here: https://github.com/akshathjain/sliding_up_panel/issues/239#issuecomment-828398264

Essentially this allows for keyboard-only scrolling through a `Scrollable` inside the `SlidingUpPanel` when using the `panelBuilder(ScrollController sc)`.

Please consider also looking at #236 since it is related in some way.