### PR TITLE
[fix] Stack crops the widgets outside (https://github.com/akshathjain…

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -329,6 +329,7 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
                     );
                   },
                   child: Stack(
+                    clipBehavior: Clip.none,  // allow to draw widgets outside the panel, e.g. attach buttons to the top of the panel
                     children: <Widget>[
                       //open panel
                       Positioned(


### PR DESCRIPTION
Solved https://github.com/akshathjain/sliding_up_panel/issues/286

Stack by default crops the widgets outside. I explicitly selected Clip.none mode.

Please note if you attach floating widgets to the header with the Stack+Positioned, don't forget to select Clip.none on it too.