### PR TITLE
Prevent from accessing AnimationController when it was disposed

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -467,6 +467,9 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
 
   // handles the sliding gesture
   void _onGestureSlide(double dy) {
+    // Prevent from accessing AnimationController methods after calling dispose on it
+    if (!mounted) return;
+
     // only slide the panel if scrolling is not enabled
     if (!_scrollingEnabled) {
       if (widget.slideDirection == SlideDirection.UP)
@@ -491,6 +494,9 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
 
   // handles when user stops sliding
   void _onGestureEnd(Velocity v) {
+    // Prevent from accessing AnimationController methods after calling dispose on it
+    if (!mounted) return;
+
     double minFlingVelocity = 365.0;
     double kSnap = 8;
 


### PR DESCRIPTION
This PR is to prevent `Null check operator used on a null value` crashes when `_onGestureSlide` or `_onGestureEnd` is called after AnimationController is being disposed.